### PR TITLE
Exclude by name patterns with wildcards

### DIFF
--- a/OpenDBDiff.Schema.SQLServer.Generates/Options/SqlOptionFilter.cs
+++ b/OpenDBDiff.Schema.SQLServer.Generates/Options/SqlOptionFilter.cs
@@ -1,54 +1,57 @@
 ﻿using OpenDBDiff.Schema.Model;
-using System.Collections.ObjectModel;
 using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace OpenDBDiff.Schema.SQLServer.Generates.Options
 {
-    public class SqlOptionFilter: IOptionFilter
+    public class SqlOptionFilter : IOptionFilter
     {
-
         public SqlOptionFilter()
         {
-            Items = new Collection<SqlOptionFilterItem>();
-            Items.Add(new SqlOptionFilterItem(ObjectType.Table, "dbo.dtproperties"));
-            Items.Add(new SqlOptionFilterItem(ObjectType.Assembly, "Microsoft.SqlServer.Types"));
-            Items.Add(new SqlOptionFilterItem(ObjectType.Schema, "db_accessadmin"));
-            Items.Add(new SqlOptionFilterItem(ObjectType.Schema, "db_backupoperator"));
-            Items.Add(new SqlOptionFilterItem(ObjectType.Schema, "db_datareader"));
-            Items.Add(new SqlOptionFilterItem(ObjectType.Schema, "db_datawriter"));
-            Items.Add(new SqlOptionFilterItem(ObjectType.Schema, "db_ddladmin"));
-            Items.Add(new SqlOptionFilterItem(ObjectType.Schema, "db_denydatareader"));
-            Items.Add(new SqlOptionFilterItem(ObjectType.Schema, "db_denydatawriter"));
-            Items.Add(new SqlOptionFilterItem(ObjectType.Schema, "db_owner"));
-            Items.Add(new SqlOptionFilterItem(ObjectType.Schema, "db_securityadmin"));
-            //Items.Add(new SqlOptionFilterItem(ObjectType.Schema, "dbo"));
-            Items.Add(new SqlOptionFilterItem(ObjectType.Schema, "guest"));
-            Items.Add(new SqlOptionFilterItem(ObjectType.Schema, "INFORMATION_SCHEMA"));
-            Items.Add(new SqlOptionFilterItem(ObjectType.Schema, "sys"));
+            Items = new List<SqlOptionFilterItem>
+            {
+                new SqlOptionFilterItem(ObjectType.Table, "dbo.dtproperties"),
+                new SqlOptionFilterItem(ObjectType.Assembly, "Microsoft.SqlServer.Types"),
+                new SqlOptionFilterItem(ObjectType.Schema, "db_accessadmin"),
+                new SqlOptionFilterItem(ObjectType.Schema, "db_backupoperator"),
+                new SqlOptionFilterItem(ObjectType.Schema, "db_datareader"),
+                new SqlOptionFilterItem(ObjectType.Schema, "db_datawriter"),
+                new SqlOptionFilterItem(ObjectType.Schema, "db_ddladmin"),
+                new SqlOptionFilterItem(ObjectType.Schema, "db_denydatareader"),
+                new SqlOptionFilterItem(ObjectType.Schema, "db_denydatawriter"),
+                new SqlOptionFilterItem(ObjectType.Schema, "db_owner"),
+                new SqlOptionFilterItem(ObjectType.Schema, "db_securityadmin"),
+                //new SqlOptionFilterItem(ObjectType.Schema, "dbo"),
+                new SqlOptionFilterItem(ObjectType.Schema, "guest"),
+                new SqlOptionFilterItem(ObjectType.Schema, "INFORMATION_SCHEMA"),
+                new SqlOptionFilterItem(ObjectType.Schema, "sys")
+            };
         }
 
         public SqlOptionFilter(IOptionFilter optionFilter)
         {
-            Items = new Collection<SqlOptionFilterItem>();
+            Items = new List<SqlOptionFilterItem>();
             var options = optionFilter.GetOptions();
-            foreach (var key in options.Keys)
+            foreach (var pair in options)
             {
-                var filter = options[key];
-                ObjectType type = (ObjectType)Enum.Parse(typeof(ObjectType), filter, true);
-                Items.Add(new SqlOptionFilterItem(type, key));
+                Items.Add(
+                    new SqlOptionFilterItem(
+                        objectType: (ObjectType)Enum.Parse(typeof(ObjectType), pair.Value, true),
+                        filterPattern: pair.Key
+                    )
+                );
             }
         }
 
-        public Collection<SqlOptionFilterItem> Items { get; private set; }
+        public IList<SqlOptionFilterItem> Items { get; private set; }
 
         public IDictionary<string, string> GetOptions()
         {
             Dictionary<string, string> values = new Dictionary<string, string>();
             for (int i = 0; i < Items.Count; i++)
             {
-                values.Add(Items[i].Filter, Items[i].Type.ToString());
+                values.Add(Items[i].FilterPattern, Items[i].ObjectType.ToString());
             }
             return values;
         }

--- a/OpenDBDiff.Schema.SQLServer.Generates/Options/SqlOptionFilterItem.cs
+++ b/OpenDBDiff.Schema.SQLServer.Generates/Options/SqlOptionFilterItem.cs
@@ -5,25 +5,25 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Options
 {
     public class SqlOptionFilterItem
     {
-        public SqlOptionFilterItem(ObjectType type, string filter)
+        public SqlOptionFilterItem(ObjectType objectType, string filterPattern)
         {
-            this.Filter = filter;
-            this.Type = type;
+            this.ObjectType = objectType;
+            this.FilterPattern = filterPattern;
         }
 
-        public ObjectType Type { get; set; }
+        public ObjectType ObjectType { get; set; }
 
-        public string Filter { get; set; }
+        public string FilterPattern { get; set; }
 
         public bool IsMatch(ISchemaBase item)
         {
-            return item.ObjectType == this.Type && item.Name.ToLower() == this.Filter.ToLower() || this.IsSchemaMatch(item);
+            return item.ObjectType.Equals(this.ObjectType) && item.Name.Equals(this.FilterPattern, StringComparison.OrdinalIgnoreCase) || this.IsSchemaMatch(item);
         }
 
         public bool IsSchemaMatch(ISchemaBase item)
         {
             if (item.Owner == null) return false;
-            return this.Type == ObjectType.Schema && item.Owner.ToLower() == this.Filter.ToLower();
+            return this.ObjectType.Equals(ObjectType.Schema) && item.Owner.Equals(this.FilterPattern, StringComparison.OrdinalIgnoreCase);
         }
 
         #region Overrides
@@ -48,13 +48,13 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Options
             {
                 return false;
             }
-            return this.Type.Equals(fi.Type) && this.Filter.Equals(fi.Filter);
+            return this.ObjectType.Equals(fi.ObjectType) && this.FilterPattern.Equals(fi.FilterPattern, StringComparison.OrdinalIgnoreCase);
         }
 
         public override int GetHashCode()
         {
             long hash = 13;
-            hash = hash + this.Type.GetHashCode() + this.Filter.GetHashCode();
+            hash = hash + this.ObjectType.GetHashCode() + this.FilterPattern.ToLowerInvariant().GetHashCode();
             return Convert.ToInt32(hash & 0x7fffffff);
         }
         #endregion

--- a/OpenDBDiff.Schema.SQLServer2005/Front/AddExclusionPatternForm.Designer.cs
+++ b/OpenDBDiff.Schema.SQLServer2005/Front/AddExclusionPatternForm.Designer.cs
@@ -36,8 +36,8 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
             this.cboObjects = new System.Windows.Forms.ComboBox();
             this.txtFilter = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
-            this.btnApply = new System.Windows.Forms.Button();
-            this.btnCancel = new System.Windows.Forms.Button();
+            this.ApplyButton = new System.Windows.Forms.Button();
+            this.CancelFormButton = new System.Windows.Forms.Button();
             this.groupBox1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -98,39 +98,39 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
             this.label1.TabIndex = 0;
             this.label1.Text = "Filter Pattern:";
             // 
-            // btnApply
+            // ApplyButton
             // 
-            this.btnApply.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnApply.Location = new System.Drawing.Point(242, 80);
-            this.btnApply.Name = "btnApply";
-            this.btnApply.Size = new System.Drawing.Size(75, 23);
-            this.btnApply.TabIndex = 1;
-            this.btnApply.Text = "Apply";
-            this.btnApply.UseVisualStyleBackColor = true;
-            this.btnApply.Click += new System.EventHandler(this.btnApply_Click);
+            this.ApplyButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.ApplyButton.Location = new System.Drawing.Point(242, 80);
+            this.ApplyButton.Name = "ApplyButton";
+            this.ApplyButton.Size = new System.Drawing.Size(75, 23);
+            this.ApplyButton.TabIndex = 1;
+            this.ApplyButton.Text = "Apply";
+            this.ApplyButton.UseVisualStyleBackColor = true;
+            this.ApplyButton.Click += new System.EventHandler(this.ApplyButton_Click);
             // 
-            // btnCancel
+            // CancelFormButton
             // 
-            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(161, 80);
-            this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(75, 23);
-            this.btnCancel.TabIndex = 2;
-            this.btnCancel.Text = "Cancel";
-            this.btnCancel.UseVisualStyleBackColor = true;
-            this.btnCancel.Click += new System.EventHandler(this.button2_Click);
+            this.CancelFormButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.CancelFormButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.CancelFormButton.Location = new System.Drawing.Point(161, 80);
+            this.CancelFormButton.Name = "CancelFormButton";
+            this.CancelFormButton.Size = new System.Drawing.Size(75, 23);
+            this.CancelFormButton.TabIndex = 2;
+            this.CancelFormButton.Text = "Cancel";
+            this.CancelFormButton.UseVisualStyleBackColor = true;
+            this.CancelFormButton.Click += new System.EventHandler(this.CancelFormButton_Click);
             // 
             // AddExclusionPatternForm
             // 
-            this.AcceptButton = this.btnApply;
+            this.AcceptButton = this.ApplyButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.CancelButton = this.btnCancel;
+            this.CancelButton = this.CancelFormButton;
             this.ClientSize = new System.Drawing.Size(324, 107);
             this.ControlBox = false;
-            this.Controls.Add(this.btnCancel);
-            this.Controls.Add(this.btnApply);
+            this.Controls.Add(this.CancelFormButton);
+            this.Controls.Add(this.ApplyButton);
             this.Controls.Add(this.groupBox1);
             this.Name = "AddExclusionPatternForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
@@ -148,7 +148,7 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
         private Label label1;
         private ComboBox cboObjects;
         private Label label2;
-        private Button btnApply;
-        private Button btnCancel;
+        private Button ApplyButton;
+        private Button CancelFormButton;
     }
 }

--- a/OpenDBDiff.Schema.SQLServer2005/Front/AddExclusionPatternForm.Designer.cs
+++ b/OpenDBDiff.Schema.SQLServer2005/Front/AddExclusionPatternForm.Designer.cs
@@ -3,7 +3,7 @@ using System.Windows.Forms;
 
 namespace OpenDBDiff.Schema.SQLServer.Generates.Front
 {
-    partial class AddItem
+    partial class AddExclusionPatternForm
     {
         /// <summary>
         /// Required designer variable.
@@ -121,7 +121,7 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.button2_Click);
             // 
-            // AddItem
+            // AddExclusionPatternForm
             // 
             this.AcceptButton = this.btnApply;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -132,7 +132,7 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnApply);
             this.Controls.Add(this.groupBox1);
-            this.Name = "AddItem";
+            this.Name = "AddExclusionPatternForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Filters";
             this.groupBox1.ResumeLayout(false);

--- a/OpenDBDiff.Schema.SQLServer2005/Front/AddExclusionPatternForm.cs
+++ b/OpenDBDiff.Schema.SQLServer2005/Front/AddExclusionPatternForm.cs
@@ -12,6 +12,10 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
         private SqlOption sqlOption;
         private int indexFilter;
 
+        public AddExclusionPatternForm(SqlOption sqlOption)
+            : this(sqlOption, -1)
+        { }
+
         public AddExclusionPatternForm(SqlOption sqlOption, int Index)
         {
             InitializeComponent();
@@ -23,7 +27,7 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
             if (indexFilter != -1)
             {
                 txtFilter.Text = sqlOption.Filters.Items[indexFilter].FilterPattern;
-                cboObjects.SelectedValue = sqlOption.Filters.Items[indexFilter].ObjectType.ToString();
+                cboObjects.SelectedValue = sqlOption.Filters.Items[indexFilter].ObjectType;
             }
         }
 

--- a/OpenDBDiff.Schema.SQLServer2005/Front/AddExclusionPatternForm.cs
+++ b/OpenDBDiff.Schema.SQLServer2005/Front/AddExclusionPatternForm.cs
@@ -1,30 +1,23 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using OpenDBDiff.Schema.SQLServer.Generates.Options;
+using System;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
-using OpenDBDiff.Schema.SQLServer.Generates.Options;
 
 namespace OpenDBDiff.Schema.SQLServer.Generates.Front
 {
     public partial class AddExclusionPatternForm : Form
     {
-        private class ObjectTypeComboBoxItem
-        {
-            public string Id { get; set; }
-            public string Name { get; set; }
-        }
-
-        private IList<ObjectTypeComboBoxItem> items = new List<ObjectTypeComboBoxItem>();
-
         private SqlOption sqlOption;
         private int indexFilter;
 
         public AddExclusionPatternForm(SqlOption sqlOption, int Index)
         {
             InitializeComponent();
-            FillCombo();
+
+            PopulateObjectTypeDropDownList();
+
             this.sqlOption = sqlOption;
             indexFilter = Index;
             if (indexFilter != -1)
@@ -50,26 +43,24 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
                 return value.ToString();
         }
 
-        private void FillCombo()
+        private void PopulateObjectTypeDropDownList()
         {
-            foreach (ObjectType state in Enum.GetValues(typeof(ObjectType)).Cast<ObjectType>())
-            {
-                var item = new ObjectTypeComboBoxItem();
-                item.Id = state.ToString();
-                item.Name = GetEnumDescription(state);
-                items.Add(item);
-            }
-            cboObjects.DataSource = items.OrderBy(i => i.Name).ToList();
-            cboObjects.DisplayMember = "Name";
-            cboObjects.ValueMember = "Id";
+            var data = Enum.GetValues(typeof(ObjectType)).Cast<ObjectType>()
+                .Select(ot => new { ObjectType = ot, Description = GetEnumDescription(ot) })
+                .OrderBy(a => a.Description)
+                .ToList();
+
+            cboObjects.DataSource = data;
+            cboObjects.DisplayMember = "Description";
+            cboObjects.ValueMember = "ObjectType";
         }
 
-        private void button2_Click(object sender, EventArgs e)
+        private void CancelFormButton_Click(object sender, EventArgs e)
         {
-            this.Dispose();
+            this.Close();
         }
 
-        private void btnApply_Click(object sender, EventArgs e)
+        private void ApplyButton_Click(object sender, EventArgs e)
         {
             if (cboObjects.SelectedItem == null)
             {
@@ -85,7 +76,6 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
                 return;
             }
 
-
             if (indexFilter == -1)
                 sqlOption.Filters.Items.Add(fi);
             else
@@ -94,7 +84,8 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
                 sqlOption.Filters.Items[indexFilter].Type = fi.Type;
             }
             HandlerHelper.RaiseOnChange();
-            this.Dispose();
+
+            this.Close();
         }
     }
 }

--- a/OpenDBDiff.Schema.SQLServer2005/Front/AddExclusionPatternForm.cs
+++ b/OpenDBDiff.Schema.SQLServer2005/Front/AddExclusionPatternForm.cs
@@ -22,8 +22,8 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
             indexFilter = Index;
             if (indexFilter != -1)
             {
-                txtFilter.Text = sqlOption.Filters.Items[indexFilter].Filter;
-                cboObjects.SelectedValue = sqlOption.Filters.Items[indexFilter].Type.ToString();
+                txtFilter.Text = sqlOption.Filters.Items[indexFilter].FilterPattern;
+                cboObjects.SelectedValue = sqlOption.Filters.Items[indexFilter].ObjectType.ToString();
             }
         }
 
@@ -72,7 +72,7 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
 
             if (sqlOption.Filters.Items.Contains(fi))
             {
-                MessageBox.Show(this, string.Format("The list of name filters already includes an entry for text '{0}' of type '{1}'", fi.Filter, fi.Type.ToString()), "Error", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                MessageBox.Show(this, string.Format("The list of name filters already includes an entry for text '{0}' of type '{1}'", fi.FilterPattern, fi.ObjectType.ToString()), "Error", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 return;
             }
 
@@ -80,8 +80,8 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
                 sqlOption.Filters.Items.Add(fi);
             else
             {
-                sqlOption.Filters.Items[indexFilter].Filter = fi.Filter;
-                sqlOption.Filters.Items[indexFilter].Type = fi.Type;
+                sqlOption.Filters.Items[indexFilter].FilterPattern = fi.FilterPattern;
+                sqlOption.Filters.Items[indexFilter].ObjectType = fi.ObjectType;
             }
             HandlerHelper.RaiseOnChange();
 

--- a/OpenDBDiff.Schema.SQLServer2005/Front/AddExclusionPatternForm.cs
+++ b/OpenDBDiff.Schema.SQLServer2005/Front/AddExclusionPatternForm.cs
@@ -8,7 +8,7 @@ using OpenDBDiff.Schema.SQLServer.Generates.Options;
 
 namespace OpenDBDiff.Schema.SQLServer.Generates.Front
 {
-    public partial class AddItem : Form
+    public partial class AddExclusionPatternForm : Form
     {
         private class ObjectTypeComboBoxItem
         {
@@ -21,7 +21,7 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
         private SqlOption sqlOption;
         private int indexFilter;
 
-        public AddItem(SqlOption sqlOption, int Index)
+        public AddExclusionPatternForm(SqlOption sqlOption, int Index)
         {
             InitializeComponent();
             FillCombo();

--- a/OpenDBDiff.Schema.SQLServer2005/Front/AddExclusionPatternForm.resx
+++ b/OpenDBDiff.Schema.SQLServer2005/Front/AddExclusionPatternForm.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>

--- a/OpenDBDiff.Schema.SQLServer2005/Front/HandlerHelper.cs
+++ b/OpenDBDiff.Schema.SQLServer2005/Front/HandlerHelper.cs
@@ -7,7 +7,7 @@
 
         public static void RaiseOnChange()
         {
-            if (OnChange != null) OnChange();
+            OnChange?.Invoke();
         }
     }
 }

--- a/OpenDBDiff.Schema.SQLServer2005/Front/SqlOptionsFront.Designer.cs
+++ b/OpenDBDiff.Schema.SQLServer2005/Front/SqlOptionsFront.Designer.cs
@@ -1070,6 +1070,7 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
             this.lstFilters.TabIndex = 0;
             this.lstFilters.UseCompatibleStateImageBehavior = false;
             this.lstFilters.View = System.Windows.Forms.View.Details;
+            this.lstFilters.DoubleClick += new System.EventHandler(this.lstFilters_DoubleClick);
             //
             // columnHeader1
             //

--- a/OpenDBDiff.Schema.SQLServer2005/Front/SqlOptionsFront.cs
+++ b/OpenDBDiff.Schema.SQLServer2005/Front/SqlOptionsFront.cs
@@ -262,5 +262,14 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
                 LoadFilters();
             }
         }
+
+        private void lstFilters_DoubleClick(object sender, EventArgs e)
+        {
+            if (lstFilters.SelectedItems.Count > 0)
+            {
+                AddExclusionPatternForm itemForm = new AddExclusionPatternForm(SQLOption, lstFilters.SelectedItems[0].Index);
+                itemForm.ShowDialog(this);
+            }
+        }
     }
 }

--- a/OpenDBDiff.Schema.SQLServer2005/Front/SqlOptionsFront.cs
+++ b/OpenDBDiff.Schema.SQLServer2005/Front/SqlOptionsFront.cs
@@ -213,14 +213,14 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
         {
             if (lstFilters.SelectedItems.Count > 0)
             {
-                AddItem itemForm = new AddItem(SQLOption, lstFilters.SelectedItems[0].Index);
+                AddExclusionPatternForm itemForm = new AddExclusionPatternForm(SQLOption, lstFilters.SelectedItems[0].Index);
                 itemForm.ShowDialog(this);
             }
         }
 
         private void btnAdd_Click(object sender, EventArgs e)
         {
-            AddItem itemForm = new AddItem(SQLOption, -1);
+            AddExclusionPatternForm itemForm = new AddExclusionPatternForm(SQLOption, -1);
             itemForm.ShowDialog(this);
         }
 

--- a/OpenDBDiff.Schema.SQLServer2005/Front/SqlOptionsFront.cs
+++ b/OpenDBDiff.Schema.SQLServer2005/Front/SqlOptionsFront.cs
@@ -26,8 +26,8 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
             lstFilters.Items.Clear();
             foreach (SqlOptionFilterItem item in SQLOption.Filters.Items)
             {
-                ListViewItem lview = new ListViewItem(item.Filter);
-                lview.SubItems.Add(item.Type.ToString());
+                var lview = new ListViewItem(item.FilterPattern);
+                lview.SubItems.Add(item.ObjectType.ToString());
                 lstFilters.Items.Add(lview);
             };
         }

--- a/OpenDBDiff.Schema.SQLServer2005/Front/SqlOptionsFront.cs
+++ b/OpenDBDiff.Schema.SQLServer2005/Front/SqlOptionsFront.cs
@@ -220,7 +220,7 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
 
         private void btnAdd_Click(object sender, EventArgs e)
         {
-            AddExclusionPatternForm itemForm = new AddExclusionPatternForm(SQLOption, -1);
+            AddExclusionPatternForm itemForm = new AddExclusionPatternForm(SQLOption);
             itemForm.ShowDialog(this);
         }
 

--- a/OpenDBDiff.Schema.SQLServer2005/Front/SqlOptionsFront.cs
+++ b/OpenDBDiff.Schema.SQLServer2005/Front/SqlOptionsFront.cs
@@ -214,14 +214,14 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Front
             if (lstFilters.SelectedItems.Count > 0)
             {
                 AddItem itemForm = new AddItem(SQLOption, lstFilters.SelectedItems[0].Index);
-                itemForm.Show(this);
+                itemForm.ShowDialog(this);
             }
         }
 
         private void btnAdd_Click(object sender, EventArgs e)
         {
             AddItem itemForm = new AddItem(SQLOption, -1);
-            itemForm.Show(this);
+            itemForm.ShowDialog(this);
         }
 
         private void chkConstraints_CheckedChanged(object sender, EventArgs e)

--- a/OpenDBDiff.Schema.SQLServer2005/OpenDBDiff.Schema.SQLServer.csproj
+++ b/OpenDBDiff.Schema.SQLServer2005/OpenDBDiff.Schema.SQLServer.csproj
@@ -68,11 +68,11 @@
     <Compile Include="..\OpenDBDiff\Properties\AssemblyVersionInfo.cs">
       <Link>Properties\AssemblyVersionInfo.cs</Link>
     </Compile>
-    <Compile Include="Front\AddItem.cs">
+    <Compile Include="Front\AddExclusionPatternForm.cs">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="Front\AddItem.Designer.cs">
-      <DependentUpon>AddItem.cs</DependentUpon>
+    <Compile Include="Front\AddExclusionPatternForm.Designer.cs">
+      <DependentUpon>AddExclusionPatternForm.cs</DependentUpon>
     </Compile>
     <Compile Include="Front\HandlerHelper.cs" />
     <Compile Include="Front\SqlOptionsFront.cs">
@@ -119,8 +119,8 @@
     <None Include="OpenDBDiff.Schema.SQLServer.snk" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Front\AddItem.resx">
-      <DependentUpon>AddItem.cs</DependentUpon>
+    <EmbeddedResource Include="Front\AddExclusionPatternForm.resx">
+      <DependentUpon>AddExclusionPatternForm.cs</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Front\SqlOptionsFront.resx">

--- a/OpenDBDiff/Front/OptionForm.Designer.cs
+++ b/OpenDBDiff/Front/OptionForm.Designer.cs
@@ -35,9 +35,9 @@ namespace OpenDBDiff.Front
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnApply = new System.Windows.Forms.Button();
             this.SuspendLayout();
-            // 
+            //
             // btnCancel
-            // 
+            //
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.btnCancel.Location = new System.Drawing.Point(433, 450);
@@ -47,9 +47,9 @@ namespace OpenDBDiff.Front
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
-            // 
+            //
             // btnApply
-            // 
+            //
             this.btnApply.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnApply.Location = new System.Drawing.Point(514, 450);
             this.btnApply.Name = "btnApply";
@@ -58,19 +58,19 @@ namespace OpenDBDiff.Front
             this.btnApply.Text = "Apply";
             this.btnApply.UseVisualStyleBackColor = true;
             this.btnApply.Click += new System.EventHandler(this.btnApply_Click);
-            // 
+            //
             // sqlOptionsFront1
-            // 
-            this.sqlOptionsFront1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            //
+            this.sqlOptionsFront1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.sqlOptionsFront1.Location = new System.Drawing.Point(3, 3);
             this.sqlOptionsFront1.Name = "sqlOptionsFront1";
             this.sqlOptionsFront1.Size = new System.Drawing.Size(586, 440);
             this.sqlOptionsFront1.TabIndex = 0;
-            // 
+            //
             // OptionForm
-            // 
+            //
             this.AcceptButton = this.btnApply;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
@@ -84,7 +84,7 @@ namespace OpenDBDiff.Front
             this.MinimizeBox = false;
             this.Name = "OptionForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Compare Options";
+            this.Text = "Comparison options";
             this.ResumeLayout(false);
 
         }

--- a/OpenDBDiff/Front/OptionForm.cs
+++ b/OpenDBDiff/Front/OptionForm.cs
@@ -7,15 +7,19 @@ namespace OpenDBDiff.Front
     {
         private IProjectHandler projectSelectorHandler;
         private Schema.Model.IOption SqlFilter;
+
         public event OptionControl.OptionEventHandler OptionSaved;
 
-
-        public OptionForm(IProjectHandler projectSelectorHandler)
+        public OptionForm(IProjectHandler projectSelectorHandler, Schema.Model.IOption filter)
         {
             this.projectSelectorHandler = projectSelectorHandler;
             sqlOptionsFront1 = projectSelectorHandler.CreateOptionControl();
             sqlOptionsFront1.OptionSaved += SqlOptionsFront1_OptionSaved;
+
             InitializeComponent();
+
+            SqlFilter = filter;
+            sqlOptionsFront1.Load(filter);
         }
 
         private void SqlOptionsFront1_OptionSaved(Schema.Model.IOption option)
@@ -23,22 +27,15 @@ namespace OpenDBDiff.Front
             OptionSaved?.Invoke(option);
         }
 
-        public void Show(IWin32Window owner, Schema.Model.IOption filter)
-        {
-            SqlFilter = filter;
-            sqlOptionsFront1.Load(filter);
-            this.Show(owner);
-        }
-
         private void btnApply_Click(object sender, EventArgs e)
         {
             sqlOptionsFront1.Save();
-            this.Dispose();
+            this.Close();
         }
 
         private void btnCancel_Click(object sender, EventArgs e)
         {
-            this.Dispose();
+            this.Close();
         }
     }
 }

--- a/OpenDBDiff/Front/PrincipalForm.cs
+++ b/OpenDBDiff/Front/PrincipalForm.cs
@@ -231,7 +231,7 @@ namespace OpenDBDiff.Front
             TreeView tree = (TreeView)schemaTreeView1.Controls.Find("treeView1", true)[0];
             ISchemaBase selected = (ISchemaBase)tree.SelectedNode.Tag;
             DataCompareForm dataCompare = new DataCompareForm(selected, LeftDatabaseSelector.ConnectionString, RightDatabaseSelector.ConnectionString);
-            dataCompare.Show();
+            dataCompare.ShowDialog();
         }
 
         private void btnCompare_Click(object sender, EventArgs e)
@@ -496,9 +496,9 @@ namespace OpenDBDiff.Front
         private void btnOptions_Click(object sender, EventArgs e)
         {
             Options = Options ?? ProjectSelectorHandler.GetDefaultProjectOptions();
-            OptionForm form = new OptionForm(this.ProjectSelectorHandler);
+            OptionForm form = new OptionForm(this.ProjectSelectorHandler, Options);
             form.OptionSaved += new OptionControl.OptionEventHandler((option) => Options = option);
-            form.Show(Owner, Options);
+            form.ShowDialog(this);
         }
 
         private void LoadProjectHandlers()

--- a/OpenDBDiff/Front/ProgressForm.cs
+++ b/OpenDBDiff/Front/ProgressForm.cs
@@ -87,7 +87,7 @@ namespace OpenDBDiff.Front
             {
                 OriginGenerator.OnProgress -= handler;
                 DestinationGenerator.OnProgress -= handler;
-                this.Dispose();
+                this.Close();
             }
         }
 


### PR DESCRIPTION
Fixes #87 

Wildcards `*` and `?` are now supported in pattern matching.