### PR TITLE
Update GenerateIndex.cs

### DIFF
--- a/OpenDBDiff.Schema.SQLServer.Generates/Generates/GenerateIndex.cs
+++ b/OpenDBDiff.Schema.SQLServer.Generates/Generates/GenerateIndex.cs
@@ -51,13 +51,13 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Generates
 
                             if (parent != null)
                             {
-                                if (indexid != (int)reader["Index_id"] || change)
+                                if (indexid != (int)reader["index_id"] || change)
                                 {
                                     item = new Index(parent);
                                     item.Name = reader["Name"].ToString();
                                     item.Owner = parent.Owner;
                                     item.Type = (Index.IndexTypeEnum)(byte)reader["type"];
-                                    item.Id = (int)reader["Index_id"];
+                                    item.Id = (int)reader["index_id"];
                                     item.IgnoreDupKey = (bool)reader["ignore_dup_key"];
                                     item.IsAutoStatistics = (bool)reader["NoAutomaticRecomputation"];
                                     item.IsDisabled = (bool)reader["is_disabled"];
@@ -80,7 +80,7 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Generates
                                     {
                                         item.FilterDefintion = reader["FilterDefinition"].ToString();
                                     }
-                                    indexid = (int)reader["Index_id"];
+                                    indexid = (int)reader["index_id"];
                                     if (type.Equals("V"))
                                         ((View)parent).Indexes.Add(item);
                                     else


### PR DESCRIPTION
In Turkish, "I" is not capital form of "i". So, Index_id and index_id are not same field name in Turkish collation. Application was breaking, so this is a vital update.