### PR TITLE
Fast assembly conversion to hex string

### DIFF
--- a/OpenDBDiff.Schema.SQLServer.Generates/Generates/GenerateAssemblies.cs
+++ b/OpenDBDiff.Schema.SQLServer.Generates/Generates/GenerateAssemblies.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Data.SqlClient;
-using System.Text;
+using OpenDBDiff.Schema.SQLServer.Generates.Generates.Util;
 using OpenDBDiff.Schema.SQLServer.Generates.Model;
 
 namespace OpenDBDiff.Schema.SQLServer.Generates.Generates
@@ -26,10 +26,7 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Generates
 
         private static string ToHex(byte[] stream)
         {
-            StringBuilder sHex = new StringBuilder(2 * stream.Length);
-            for (int i = 0; i < stream.Length; i++)
-                sHex.AppendFormat("{0:X2} ", stream[i]);
-            return "0x" + sHex.ToString().Replace(" ", String.Empty);
+            return ByteToHexEncoder.ByteArrayToHex(stream);
         }
 
         private static void FillFiles(Database database, string connectionString)

--- a/OpenDBDiff.Schema.SQLServer.Generates/Generates/Util/ByteToHexEncoder.cs
+++ b/OpenDBDiff.Schema.SQLServer.Generates/Generates/Util/ByteToHexEncoder.cs
@@ -1,0 +1,38 @@
+﻿namespace OpenDBDiff.Schema.SQLServer.Generates.Generates.Util
+{
+    /// <summary>
+    /// This class implements a fast conversion from a byte array to an hex string.
+    /// </summary>
+    public class ByteToHexEncoder
+    {
+        private static readonly uint[] _lookup32 = CreateLookup32();
+
+        private static uint[] CreateLookup32()
+        {
+            var result = new uint[256];
+            for (int i = 0; i < 256; i++)
+            {
+                var s = i.ToString("X2");
+                result[i] = ((uint)s[0]) + ((uint)s[1] << 16);
+            }
+            return result;
+        }
+
+        public static string ByteArrayToHex(byte[] bytes)
+        {
+            var result = new char[2 + bytes.Length * 2];
+
+            result[0] = '0';
+            result[1] = 'x';
+
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                var val = _lookup32[bytes[i]];
+                result[2 * i + 2] = (char)val;
+                result[2 * i + 3] = (char)(val >> 16);
+            }
+
+            return new string(result);
+        }
+    }
+}

--- a/OpenDBDiff.Schema.SQLServer.Generates/OpenDBDiff.Schema.SQLServer.Generates.csproj
+++ b/OpenDBDiff.Schema.SQLServer.Generates/OpenDBDiff.Schema.SQLServer.Generates.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Generates\SQLCommands\UserDataTypeCommand.cs" />
     <Compile Include="Generates\SQLCommands\UserSQLCommand.cs" />
     <Compile Include="Generates\SQLCommands\ViewSQLCommand.cs" />
+    <Compile Include="Generates\Util\ByteToHexEncoder.cs" />
     <Compile Include="Generates\Util\Constants.cs" />
     <Compile Include="Generates\Util\ConvertType.cs" />
     <Compile Include="Model\Assembly.cs" />

--- a/OpenDBDiff.Schema.SQLServer.GeneratesTests/Generates/Util/ByteToHexEncoderTests.cs
+++ b/OpenDBDiff.Schema.SQLServer.GeneratesTests/Generates/Util/ByteToHexEncoderTests.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenDBDiff.Schema.SQLServer.Generates.Generates.Util;
+
+namespace OpenDBDiff.Schema.SQLServer.Generates.Generates.Utils.Tests
+{
+    [TestClass]
+    public class ByteToHexEncoderTests
+    {
+        [TestMethod]
+        public void EncodesBytesIntoHex()
+        {
+            byte[] bytes = { 0, 1, 2, 4, 8, 16, 32, 64, 128, 255 };
+
+            var hex = ByteToHexEncoder.ByteArrayToHex(bytes);
+
+            Assert.AreEqual("0x000102040810204080FF", hex);
+        }
+    }
+}

--- a/OpenDBDiff.Schema.SQLServer.GeneratesTests/OpenDBDiff.Schema.SQLServer.GeneratesTests.csproj
+++ b/OpenDBDiff.Schema.SQLServer.GeneratesTests/OpenDBDiff.Schema.SQLServer.GeneratesTests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="..\OpenDBDiff\Properties\AssemblyVersionInfo.cs">
       <Link>Properties\AssemblyVersionInfo.cs</Link>
     </Compile>
+    <Compile Include="Generates\Util\ByteToHexEncoderTests.cs" />
     <Compile Include="Model\ColumnsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
On a test database, OpenDBDiff is taking 27% of its runtime in GenerateAssemblies:Fill. Most of this time is taken to convert the assembly bytes to a hex string. Here this code is optimized with a lookup technique. After the change, GenerateAssemblies:Fill only takes 3% of the total runtime.

Reference for hex encoding performance: https://stackoverflow.com/questions/311165/how-do-you-convert-a-byte-array-to-a-hexadecimal-string-and-vice-versa