### PR TITLE
Use Tsql-Parser to format the CREATE calls instead of Regex

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have CRLF line endings on checkout.
+# required for unit tests to pass on any platform
+*.sql text eol=crlf 

--- a/OpenDBDiff.SqlServer.Schema/Model/Util/FormatCode.cs
+++ b/OpenDBDiff.SqlServer.Schema/Model/Util/FormatCode.cs
@@ -1,17 +1,119 @@
 ﻿using OpenDBDiff.Abstractions.Schema.Model;
 using System;
 using System.Text.RegularExpressions;
+using TSQL;
+using TSQL.Tokens;
 
 namespace OpenDBDiff.SqlServer.Schema.Model.Util
 {
     internal static class FormatCode
     {
+        private static readonly Regex RegCreateAlter = new Regex("CREATE", RegexOptions.Compiled);
+        private static readonly Regex SchemaBindingRegex = new Regex("WITH SCHEMABINDING", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly char[] TrimCharacters = { ' ', '\r', '\n', '\t' };
 
-        private class SearchItem
+        /// <summary>
+        /// Find the first entry with the full name within a function, store, view, trigger or rule.
+        /// Ignore comments.
+        /// </summary>
+        public static SearchItem FindAndNormalizeCreate(ISchemaBase item, string prevText)
         {
-            public int FindPosition;
-            public string Body = "";
+            var result = FindCreate(prevText) ?? throw new InvalidOperationException($"Could not find the CREATE statement for object '{item.Name}'");
+
+            // normalize the object name for better comparison
+            var body = prevText.Substring(0, result.TypeEndPosition + 1) + " " + item.FullName + prevText.Substring(result.NameEndPosition + 1);
+
+            return new SearchItem { Body = body, FindPosition = result.CreateBeginPosition };
+        }
+
+        public static FindCreateStatementResult FindCreate(string body)
+        {
+            var tokenizer = new TSQLTokenizer(body);
+
+            tokenizer.MoveNext();
+
+            while (tokenizer.Current != null && tokenizer.Current.AsKeyword?.Keyword != TSQLKeywords.CREATE)
+            {
+                tokenizer.MoveNext();
+            }
+
+            if (tokenizer.Current == null)
+                // Oops, we reached the end of the file and did not find the CREATE!
+                return null;
+
+            var createToken = tokenizer.Current.AsKeyword;
+
+            tokenizer.MoveNext();
+
+            var typeKeyword = tokenizer.Current.AsKeyword;
+
+            tokenizer.MoveNext();
+
+            // the object owner is optional
+            var token0 = tokenizer.Current;
+            tokenizer.MoveNext();
+            var token1 = tokenizer.Current;
+            tokenizer.MoveNext();
+            var token2 = tokenizer.Current;
+            tokenizer.MoveNext();
+
+            TSQLIdentifier entityNameToken;
+            if (token1.AsCharacter?.Text == ".")
+            {
+                entityNameToken = token2.AsIdentifier;
+            }
+            else
+            {
+                entityNameToken = token0.AsIdentifier;
+            }
+
+            return new FindCreateStatementResult
+            {
+                CreateBeginPosition = createToken.BeginPosition,
+                TypeEndPosition = typeKeyword.EndPosition,
+                NameEndPosition = entityNameToken.EndPosition
+            };
+        }
+
+        public static string FormatAlter(string ObjectType, string body, ISchemaBase item, Boolean quitSchemaBinding)
+        {
+            string prevText = null;
+            try
+            {
+                prevText = (string)body.Clone();
+                SearchItem sitem = FindAndNormalizeCreate(item, prevText);
+
+                if (!quitSchemaBinding)
+                    return RegCreateAlter.Replace(sitem.Body, "ALTER", 1, sitem.FindPosition);
+                //return prevText.Substring(0, iFind) + "ALTER " + sitem.ObjectType + " " + prevText.Substring(iFind + sitem.ObjectType.Length + 7, prevText.Length - (iFind + sitem.ObjectType.Length + 7)).TrimStart();
+                else
+                {
+                    string text = RegCreateAlter.Replace(sitem.Body, "ALTER", 1, sitem.FindPosition);
+                    return SchemaBindingRegex.Replace(text, "");
+                }
+                //return "";
+            }
+            catch
+            {
+                return prevText;
+            }
+        }
+
+        public static string FormatCreate(string ObjectType, string body, ISchemaBase item)
+        {
+            try
+            {
+                string prevText = (string)body.Clone();
+                prevText = FindAndNormalizeCreate(item, prevText).Body;
+                if (String.IsNullOrEmpty(prevText))
+                    prevText = body;
+                prevText = CleanLast(prevText);
+                return SmartGO(prevText);
+            }
+            catch
+            {
+                return SmartGO(CleanLast(body));
+            }
         }
 
         /// <summary>
@@ -28,7 +130,7 @@ namespace OpenDBDiff.SqlServer.Schema.Model.Util
         }
 
         /// <summary>
-        /// Inserta la sentencia GO dentro del body
+        /// Ensure statement ends with a GO statement
         /// </summary>
         private static string SmartGO(string code)
         {
@@ -45,94 +147,17 @@ namespace OpenDBDiff.SqlServer.Schema.Model.Util
             }
         }
 
-        /// <summary>
-        /// Busca la primer entrada con el nombre completo dentro de una funcion, store, vista, trigger o rule.
-        /// Ignora los comentarios.
-        /// </summary>
-        private static SearchItem FindCreate(string ObjectType, ISchemaBase item, string prevText)
+        internal struct SearchItem
         {
-            var searchItem = new SearchItem();
-            Regex regex = new Regex(@"((/\*)(\w|\s|\d|\[|\]|\.)*(\*/))|((\-\-)(.)*)", RegexOptions.IgnoreCase);
-            Regex reg2 = new Regex(@"CREATE " + ObjectType + @"(\s|\r|\n|\t|\w|\/|\*|-|@|_|&|#)*((\[)?" + item.Owner + @"(\])?((\s)*)?\.)?((\s)*)?(\[)?" + item.Name + @"(\])?", RegexOptions.IgnoreCase | RegexOptions.Multiline);
-            Regex reg3 = new Regex(@"((\[)?" + item.Owner + @"(\])?\.)?((\s)+\.)?(\s)*(\[)?" + item.Name + @"(\])?", RegexOptions.IgnoreCase);
-            Regex reg4 = new Regex(@"( )*\[");
-            //Regex reg3 = new Regex(@"((\[)?" + item.Owner + @"(\])?.)?(\[)?" + item.Name + @"(\])?", RegexOptions.Multiline);
-
-            var matches = regex.Matches(prevText);
-            Boolean finish = false;
-            int indexStart = 0;
-            int indexBegin = 0;
-            int iAux = -1;
-
-            while (!finish)
-            {
-                Match match = reg2.Match(prevText, indexBegin);
-                if (match.Success)
-                    iAux = match.Index;
-                else
-                    iAux = -1;
-                if ((matches.Count == indexStart) || (match.Success))
-                    finish = true;
-                else
-                {
-                    if ((iAux < matches[indexStart].Index) || (iAux > matches[indexStart].Index + matches[indexStart].Length))
-                        finish = true;
-                    else
-                    {
-                        //indexBegin = abiertas[indexStart].Index + abiertas[indexStart].Length;
-                        indexBegin = iAux + 1;
-                        indexStart++;
-                    }
-                }
-            }
-            string result = reg3.Replace(prevText, " " + item.FullName, 1, iAux + 1);
-            if (iAux != -1)
-                searchItem.Body = reg4.Replace(result, " [", 1, iAux);
-            searchItem.FindPosition = iAux;
-            return searchItem;
+            public string Body;
+            public int FindPosition;
         }
 
-        public static string FormatCreate(string ObjectType, string body, ISchemaBase item)
+        internal class FindCreateStatementResult
         {
-            try
-            {
-                string prevText = (string)body.Clone();
-                prevText = FindCreate(ObjectType, item, prevText).Body;
-                if (String.IsNullOrEmpty(prevText))
-                    prevText = body;
-                prevText = CleanLast(prevText);
-                return SmartGO(prevText);
-            }
-            catch
-            {
-                return SmartGO(CleanLast(body));
-            }
-        }
-
-        public static string FormatAlter(string ObjectType, string body, ISchemaBase item, Boolean quitSchemaBinding)
-        {
-            string prevText = null;
-            try
-            {
-                prevText = (string)body.Clone();
-                SearchItem sitem = FindCreate(ObjectType, item, prevText);
-                Regex regAlter = new Regex("CREATE");
-
-                if (!quitSchemaBinding)
-                    return regAlter.Replace(sitem.Body, "ALTER", 1, sitem.FindPosition);
-                //return prevText.Substring(0, iFind) + "ALTER " + sitem.ObjectType + " " + prevText.Substring(iFind + sitem.ObjectType.Length + 7, prevText.Length - (iFind + sitem.ObjectType.Length + 7)).TrimStart();
-                else
-                {
-                    string text = regAlter.Replace(sitem.Body, "ALTER", 1, sitem.FindPosition);
-                    Regex regex = new Regex("WITH SCHEMABINDING", RegexOptions.IgnoreCase);
-                    return regex.Replace(text, "");
-                }
-                //return "";
-            }
-            catch
-            {
-                return prevText;
-            }
+            public int CreateBeginPosition;
+            public int NameEndPosition;
+            public int TypeEndPosition;
         }
     }
 }

--- a/OpenDBDiff.SqlServer.Schema/OpenDBDiff.SqlServer.Schema.csproj
+++ b/OpenDBDiff.SqlServer.Schema/OpenDBDiff.SqlServer.Schema.csproj
@@ -47,6 +47,9 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="TSQL_Parser, Version=1.5.2.0, Culture=neutral, PublicKeyToken=09a45a2da17eccd6, processorArchitecture=MSIL">
+      <HintPath>..\packages\TSQL.Parser.1.5.2\lib\net452\TSQL_Parser.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\OpenDBDiff\Properties\AssemblyVersionInfo.cs">
@@ -254,6 +257,7 @@
     <None Include="..\.editorconfig">
       <Link>.editorconfig</Link>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenDBDiff.Abstractions.Schema\OpenDBDiff.Abstractions.Schema.csproj">

--- a/OpenDBDiff.SqlServer.Schema/Properties/AssemblyInfo.cs
+++ b/OpenDBDiff.SqlServer.Schema/Properties/AssemblyInfo.cs
@@ -23,3 +23,5 @@ using System.Runtime.InteropServices;
 [assembly: Guid("32ac9af6-db93-4354-b69f-6dbc65c70867")]
 
 [assembly: System.CLSCompliant(true)]
+
+[assembly:InternalsVisibleTo("OpenDBDiff.Tests")]

--- a/OpenDBDiff.SqlServer.Schema/packages.config
+++ b/OpenDBDiff.SqlServer.Schema/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="TSQL.Parser" version="1.5.2" targetFramework="net452" />
+</packages>

--- a/OpenDBDiff.Tests/Model/FormatCodeTests.cs
+++ b/OpenDBDiff.Tests/Model/FormatCodeTests.cs
@@ -1,0 +1,129 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using OpenDBDiff.Abstractions.Schema.Model;
+using OpenDBDiff.SqlServer.Schema.Model.Util;
+using OpenDBDiff.Tests.Utils;
+using System;
+
+namespace OpenDBDiff.Tests.Model.Tests
+{
+    [TestClass]
+    public class FormatCodeTests
+    {
+        private readonly ResourceFileExtractor extractor;
+
+        public FormatCodeTests()
+        {
+            this.extractor = new ResourceFileExtractor(".SqlSnippets.Triggers.");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void FindAndNormalizeCreate_BrokenThrowsException()
+        {
+            var triggerItemMock = new Mock<ISchemaBase>();
+            triggerItemMock.Setup(x => x.FullName).Returns("[dbo].[iutrgTriggerName]");
+
+            FormatCode.FindAndNormalizeCreate(triggerItemMock.Object, extractor.ReadFileFromResource("broken.sql"));
+        }
+
+        [TestMethod]
+        public void FindAndNormalizeCreate_NoBracket_ShouldNormalize()
+        {
+            var triggerItemMock = new Mock<ISchemaBase>();
+            triggerItemMock.Setup(x => x.FullName).Returns("[dbo].[iutrgTriggerName]");
+
+            var a = FormatCode.FindAndNormalizeCreate(triggerItemMock.Object, extractor.ReadFileFromResource("no-brackets.sql"));
+
+            var normalized = extractor.ReadFileFromResource("normalized.sql");
+            Assert.AreEqual(normalized, a.Body);
+            Assert.AreEqual(0, a.FindPosition);
+        }
+
+        [TestMethod]
+        public void FindAndNormalizeCreate_NoOwner_ShouldNormalize()
+        {
+            var triggerItemMock = new Mock<ISchemaBase>();
+            triggerItemMock.Setup(x => x.FullName).Returns("[dbo].[iutrgTriggerName]");
+
+            var a = FormatCode.FindAndNormalizeCreate(triggerItemMock.Object, extractor.ReadFileFromResource("no-owner.sql"));
+
+            var normalized = extractor.ReadFileFromResource("normalized.sql");
+            Assert.AreEqual(normalized, a.Body);
+            Assert.AreEqual(0, a.FindPosition);
+        }
+
+        [TestMethod]
+        public void FindAndNormalizeCreate_NormalizedSql_ShouldKeepSourceText()
+        {
+            var triggerItemMock = new Mock<ISchemaBase>();
+            triggerItemMock.Setup(x => x.FullName).Returns("[dbo].[iutrgTriggerName]");
+
+            var normalized = extractor.ReadFileFromResource("normalized.sql");
+            var a = FormatCode.FindAndNormalizeCreate(triggerItemMock.Object, normalized);
+
+            Assert.AreEqual(normalized, a.Body);
+            Assert.AreEqual(0, a.FindPosition);
+        }
+
+        [TestMethod]
+        public void FindAndNormalizeCreate_WithComment_ShouldNormalize()
+        {
+            var triggerItemMock = new Mock<ISchemaBase>();
+            triggerItemMock.Setup(x => x.FullName).Returns("[dbo].[iutrgTriggerName]");
+
+            var a = FormatCode.FindAndNormalizeCreate(triggerItemMock.Object, extractor.ReadFileFromResource("with-comments.sql"));
+
+            var normalized = extractor.ReadFileFromResource("normalized.sql");
+            Assert.AreEqual(62, a.FindPosition);
+            Assert.AreEqual(normalized, a.Body.Substring(a.FindPosition));
+        }
+
+        [TestMethod]
+        public void FindCreate_BrokenReturnsNull()
+        {
+            var findResult = FormatCode.FindCreate(extractor.ReadFileFromResource("broken.sql"));
+            Assert.IsNull(findResult);
+        }
+
+        [TestMethod]
+        public void FindCreate_NoBracket_ShouldFindTheCreatePositions()
+        {
+            var findResult = FormatCode.FindCreate(extractor.ReadFileFromResource("no-brackets.sql"));
+
+            Assert.AreEqual(0, findResult.CreateBeginPosition);
+            Assert.AreEqual(13, findResult.TypeEndPosition);
+            Assert.AreEqual(30, findResult.NameEndPosition);
+        }
+
+        [TestMethod]
+        public void FindCreate_NoOwner_ShouldFindTheCreatePositions()
+        {
+            var findResult = FormatCode.FindCreate(extractor.ReadFileFromResource("no-owner.sql"));
+
+            Assert.AreEqual(0, findResult.CreateBeginPosition);
+            Assert.AreEqual(13, findResult.TypeEndPosition);
+            Assert.AreEqual(32, findResult.NameEndPosition);
+        }
+
+        [TestMethod]
+        public void FindCreate_Normalized_ShouldFindTheCreatePositions()
+        {
+            var findResult = FormatCode.FindCreate(extractor.ReadFileFromResource("normalized.sql"));
+
+            Assert.AreEqual(0, findResult.CreateBeginPosition);
+            Assert.AreEqual(13, findResult.TypeEndPosition);
+            Assert.AreEqual(38, findResult.NameEndPosition);
+        }
+
+        [TestMethod]
+        public void FindCreate_WithComment_ShouldFindTheCreatePositions()
+        {
+            var findResult = FormatCode.FindCreate(extractor.ReadFileFromResource("with-comments.sql"));
+
+            Assert.AreEqual(62, findResult.CreateBeginPosition);
+            Assert.AreEqual(75, findResult.TypeEndPosition);
+            Assert.AreEqual(100, findResult.NameEndPosition);
+        }
+    }
+}

--- a/OpenDBDiff.Tests/OpenDBDiff.Tests.csproj
+++ b/OpenDBDiff.Tests/OpenDBDiff.Tests.csproj
@@ -38,7 +38,23 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.4.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.7.145.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.7.145\lib\net45\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -58,7 +74,9 @@
     </Compile>
     <Compile Include="Generates\Util\ByteToHexEncoderTests.cs" />
     <Compile Include="Model\ColumnsTests.cs" />
+    <Compile Include="Model\FormatCodeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utils\ResourceFileExtractor.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenDBDiff.Abstractions.Schema\OpenDBDiff.Abstractions.Schema.csproj">
@@ -74,6 +92,16 @@
     <None Include="..\.editorconfig">
       <Link>.editorconfig</Link>
     </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="SqlSnippets\Triggers\no-brackets.sql" />
+    <EmbeddedResource Include="SqlSnippets\Triggers\no-owner.sql" />
+    <EmbeddedResource Include="SqlSnippets\Triggers\normalized.sql" />
+    <EmbeddedResource Include="SqlSnippets\Triggers\with-comments.sql" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="SqlSnippets\Triggers\broken.sql" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/OpenDBDiff.Tests/SqlSnippets/Triggers/broken.sql
+++ b/OpenDBDiff.Tests/SqlSnippets/Triggers/broken.sql
@@ -1,0 +1,7 @@
+EATE TRIGGER iutrgTriggerName ON dbo.TableName
+FOR INSERT, UPDATE
+AS
+UPDATE TableName
+SET 	TableName.SomeColumn = 'something'
+FROM	inserted,TableName
+WHERE inserted.TableNameId = TableName.TableNameId

--- a/OpenDBDiff.Tests/SqlSnippets/Triggers/no-brackets.sql
+++ b/OpenDBDiff.Tests/SqlSnippets/Triggers/no-brackets.sql
@@ -1,0 +1,7 @@
+CREATE TRIGGER iutrgTriggerName ON dbo.TableName
+FOR INSERT, UPDATE
+AS
+UPDATE TableName
+SET 	TableName.SomeColumn = 'something'
+FROM	inserted,TableName
+WHERE inserted.TableNameId = TableName.TableNameId

--- a/OpenDBDiff.Tests/SqlSnippets/Triggers/no-owner.sql
+++ b/OpenDBDiff.Tests/SqlSnippets/Triggers/no-owner.sql
@@ -1,0 +1,7 @@
+CREATE TRIGGER [iutrgTriggerName] ON dbo.TableName
+FOR INSERT, UPDATE
+AS
+UPDATE TableName
+SET 	TableName.SomeColumn = 'something'
+FROM	inserted,TableName
+WHERE inserted.TableNameId = TableName.TableNameId

--- a/OpenDBDiff.Tests/SqlSnippets/Triggers/normalized.sql
+++ b/OpenDBDiff.Tests/SqlSnippets/Triggers/normalized.sql
@@ -1,0 +1,7 @@
+CREATE TRIGGER [dbo].[iutrgTriggerName] ON dbo.TableName
+FOR INSERT, UPDATE
+AS
+UPDATE TableName
+SET 	TableName.SomeColumn = 'something'
+FROM	inserted,TableName
+WHERE inserted.TableNameId = TableName.TableNameId

--- a/OpenDBDiff.Tests/SqlSnippets/Triggers/with-comments.sql
+++ b/OpenDBDiff.Tests/SqlSnippets/Triggers/with-comments.sql
@@ -1,0 +1,9 @@
+/* test comment CREATE TRIGGER [test] */
+-- Another comment
+CREATE TRIGGER [dbo].[iutrgTriggerName] ON dbo.TableName
+FOR INSERT, UPDATE
+AS
+UPDATE TableName
+SET 	TableName.SomeColumn = 'something'
+FROM	inserted,TableName
+WHERE inserted.TableNameId = TableName.TableNameId

--- a/OpenDBDiff.Tests/Utils/ResourceFileExtractor.cs
+++ b/OpenDBDiff.Tests/Utils/ResourceFileExtractor.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+
+namespace OpenDBDiff.Tests.Utils
+{
+    /// <summary>
+    /// Summary description for ResourceFileExtractor.
+    /// </summary>
+    public sealed class ResourceFileExtractor
+    {
+        #region Static
+
+        #region Private fields
+
+        private static readonly IDictionary<string, ResourceFileExtractor> extractors = new ConcurrentDictionary<string, ResourceFileExtractor>();
+
+        #endregion Private fields
+
+        #region Public properties
+
+        /// <summary>Instance of resource extractor for executing assembly </summary>
+        public static ResourceFileExtractor Instance
+        {
+            get
+            {
+                Assembly _assembly = Assembly.GetCallingAssembly();
+                string _key = _assembly.GetName().FullName;
+                if (!extractors.TryGetValue(_key, out ResourceFileExtractor extractor)
+                    && !extractors.TryGetValue(_key, out extractor))
+                {
+                    extractor = new ResourceFileExtractor(_assembly, true, null);
+                    extractors.Add(_key, extractor);
+                }
+
+                return extractor;
+            }
+        }
+
+        #endregion Public properties
+
+        #endregion Static
+
+        #region Private fields
+
+        private readonly ResourceFileExtractor m_baseExtractor;
+
+        #endregion Private fields
+
+        #region Constructors
+
+        /// <summary>
+        /// Create instance
+        /// </summary>
+        /// <param name="resourceFilePath"><c>ResourceFilePath</c> in assembly. Example: .Properties.Scripts.</param>
+        /// <param name="baseExtractor"></param>
+        public ResourceFileExtractor(string resourceFilePath, ResourceFileExtractor baseExtractor)
+                : this(Assembly.GetCallingAssembly(), baseExtractor)
+        {
+            ResourceFilePath = resourceFilePath;
+        }
+
+        /// <summary>
+        /// Create instance
+        /// </summary>
+        /// <param name="baseExtractor"></param>
+        public ResourceFileExtractor(ResourceFileExtractor baseExtractor)
+                : this(Assembly.GetCallingAssembly(), baseExtractor)
+        {
+        }
+
+        /// <summary>
+        /// Create instance
+        /// </summary>
+        /// <param name="resourcePath"><c>ResourceFilePath</c> in assembly. Example: .Properties.Scripts.</param>
+        public ResourceFileExtractor(string resourcePath)
+                : this(Assembly.GetCallingAssembly(), resourcePath)
+        {
+        }
+
+        /// <summary>
+        /// Instance constructor
+        /// </summary>
+        /// <param name="assembly"></param>
+        /// <param name="resourcePath"></param>
+        public ResourceFileExtractor(Assembly assembly, string resourcePath)
+                : this(assembly ?? Assembly.GetCallingAssembly())
+        {
+            ResourceFilePath = resourcePath;
+        }
+
+        /// <summary>
+        /// Instance constructor
+        /// </summary>
+        public ResourceFileExtractor()
+                : this(Assembly.GetCallingAssembly())
+        {
+        }
+
+        /// <summary>
+        /// Instance constructor
+        /// </summary>
+        /// <param name="assembly"></param>
+        public ResourceFileExtractor(Assembly assembly)
+                : this(assembly ?? Assembly.GetCallingAssembly(), (ResourceFileExtractor)null)
+        {
+        }
+
+        /// <summary>
+        /// Instance constructor
+        /// </summary>
+        /// <param name="assembly"></param>
+        /// <param name="baseExtractor"></param>
+        public ResourceFileExtractor(Assembly assembly, ResourceFileExtractor baseExtractor)
+                : this(assembly ?? Assembly.GetCallingAssembly(), false, baseExtractor)
+        {
+        }
+
+        /// <summary>
+        /// Instance constructor
+        /// </summary>
+        /// <param name="assembly"></param>
+        /// <param name="isStatic"></param>
+        /// <param name="baseExtractor"></param>
+        /// <exception cref="ArgumentNullException">Argument is null.</exception>
+        private ResourceFileExtractor(Assembly assembly, bool isStatic, ResourceFileExtractor baseExtractor)
+        {
+            #region Check
+
+            if (assembly is null)
+            {
+                throw new ArgumentNullException("assembly");
+            }
+
+            #endregion Check
+
+            Assembly = assembly;
+            m_baseExtractor = baseExtractor;
+            AssemblyName = Assembly.GetName().Name;
+            IsStatic = isStatic;
+            ResourceFilePath = ".Resources.";
+        }
+
+        #endregion Constructors
+
+        #region Public properties
+
+        /// <summary> Work assembly </summary>
+        public Assembly Assembly { get; }
+
+        /// <summary> Work assembly name </summary>
+        public string AssemblyName { get; }
+
+        public bool IsStatic { get; set; }
+
+        /// <summary>
+        /// Path to read resource files. Example: .Resources.Upgrades.
+        /// </summary>
+        public string ResourceFilePath { get; }
+
+        public IEnumerable<string> GetFileNames(Func<String, Boolean> predicate = null)
+        {
+            predicate = predicate ?? (s => true);
+
+            string _path = AssemblyName + ResourceFilePath;
+            foreach (string _resourceName in Assembly.GetManifestResourceNames())
+            {
+                if (_resourceName.StartsWith(_path) && predicate(_resourceName))
+                {
+                    yield return _resourceName.Replace(_path, string.Empty);
+                }
+            }
+        }
+
+        #endregion Public properties
+
+        #region Public methods
+
+        public string ReadFileFromResource(string fileName)
+        {
+            Stream _stream = ReadFileFromResourceToStream(fileName);
+            string _result;
+            StreamReader sr = new StreamReader(_stream);
+            try
+            {
+                _result = sr.ReadToEnd();
+            }
+            finally
+            {
+                sr.Close();
+            }
+            return _result;
+        }
+
+        public string ReadFileFromResourceFormat(string fileName, params object[] formatArgs)
+        {
+            return string.Format(ReadFileFromResource(fileName), formatArgs);
+        }
+
+        /// <summary>
+        /// Read file in current assembly by specific file name
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <returns></returns>
+        /// <exception cref="ApplicationException"><c>ApplicationException</c>.</exception>
+        public Stream ReadFileFromResourceToStream(string fileName)
+        {
+            string _nameResFile = AssemblyName + ResourceFilePath + fileName;
+            Stream _stream = Assembly.GetManifestResourceStream(_nameResFile);
+
+            #region Not found
+
+            if (_stream is null)
+            {
+                #region Get from base extractor
+
+                if (!(m_baseExtractor is null))
+                {
+                    return m_baseExtractor.ReadFileFromResourceToStream(fileName);
+                }
+
+                #endregion Get from base extractor
+
+                throw new ArgumentException("Can't find resource file " + _nameResFile, nameof(fileName));
+            }
+
+            #endregion Not found
+
+            return _stream;
+        }
+
+        /// <summary>
+        /// Read file in current assembly by specific path
+        /// </summary>
+        /// <param name="specificPath">Specific path</param>
+        /// <param name="fileName">Read file name</param>
+        /// <returns></returns>
+        public string ReadSpecificFileFromResource(string specificPath, string fileName)
+        {
+            ResourceFileExtractor _ext = new ResourceFileExtractor(Assembly, specificPath);
+            return _ext.ReadFileFromResource(fileName);
+        }
+
+        #endregion Public methods
+    }
+}

--- a/OpenDBDiff.Tests/packages.config
+++ b/OpenDBDiff.Tests/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="4.4.1" targetFramework="net452" />
+  <package id="Moq" version="4.7.145" targetFramework="net452" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net452" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
The code in FormatCode.cs is using several Regex objects to parse and normalize the CREATE statements. This tends to be slow, mostly because Regex objects are usually better when they are static. However, generalizing the Regex used here to make them static also makes them much slower.

Instead of trying to fix the Regex, here this code is replaced by the use of the Tsql-parser library (an open source project on Github). This is much faster, and also simplifies the code, since the complex Regex used to detect SQL comments are not needed anymore.

Before the change, FormatCode:FindCreate takes 17.9 % of the runtime on a test database.
After the change, FormatCode:FindAndNormalizeCreate (the equivalent method, renamed) is only taking 6.3 %.