### PR TITLE
Fix issue where constraints (check, FK, PK) are not generated when the...

### DIFF
--- a/OpenDBDiff.Schema.SQLServer.Generates/Generates/GenerateConstraint.cs
+++ b/OpenDBDiff.Schema.SQLServer.Generates/Generates/GenerateConstraint.cs
@@ -45,20 +45,23 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Generates
                                 else
                                     table = database.TablesTypes.Find(parentId);
                             }
-                            item = new Constraint(table);
-                            item.Id = (int)reader["id"];
-                            item.Name = reader["Name"].ToString();
-                            item.Type = Constraint.ConstraintType.Check;
-                            item.Definition = reader["Definition"].ToString();
-                            item.WithNoCheck = (bool)reader["WithCheck"];
-                            item.IsDisabled = (bool)reader["is_disabled"];
-                            item.Owner = reader["Owner"].ToString();
-                            if (database.Options.Ignore.FilterNotForReplication)
-                                item.NotForReplication = (bool)reader["is_not_for_replication"];
-                            if (reader["ObjectType"].ToString().Trim().Equals("U"))
-                                ((Table)table).Constraints.Add(item);
-                            else
-                                ((TableType)table).Constraints.Add(item);
+                            if (table != null)
+                            {
+                                item = new Constraint(table);
+                                item.Id = (int)reader["id"];
+                                item.Name = reader["Name"].ToString();
+                                item.Type = Constraint.ConstraintType.Check;
+                                item.Definition = reader["Definition"].ToString();
+                                item.WithNoCheck = (bool)reader["WithCheck"];
+                                item.IsDisabled = (bool)reader["is_disabled"];
+                                item.Owner = reader["Owner"].ToString();
+                                if (database.Options.Ignore.FilterNotForReplication)
+                                    item.NotForReplication = (bool)reader["is_not_for_replication"];
+                                if (reader["ObjectType"].ToString().Trim().Equals("U"))
+                                    ((Table)table).Constraints.Add(item);
+                                else
+                                    ((TableType)table).Constraints.Add(item);
+                            }
                         }
                     }
                 }
@@ -96,33 +99,37 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Generates
                                 parentId = (int)reader["parent_object_id"];
                                 table = database.Tables.Find(parentId);
                             }
-                            if (lastid != (int)reader["object_id"])
+
+                            if (table != null)
                             {
-                                con = new Constraint(table);
-                                con.Id = (int)reader["object_id"];
-                                con.Name = reader["Name"].ToString();
-                                con.Type = Constraint.ConstraintType.ForeignKey;
-                                con.WithNoCheck = (bool)reader["is_not_trusted"];
-                                con.RelationalTableFullName = "[" + reader["ReferenceOwner"].ToString() + "].[" + reader["TableRelationalName"].ToString() + "]";
-                                con.RelationalTableId = (int)reader["TableRelationalId"];
-                                con.Owner = reader["Owner"].ToString();
-                                con.IsDisabled = (bool)reader["is_disabled"];
-                                con.OnDeleteCascade = (byte)reader["delete_referential_action"];
-                                con.OnUpdateCascade = (byte)reader["update_referential_action"];
-                                if (database.Options.Ignore.FilterNotForReplication)
-                                    con.NotForReplication = (bool)reader["is_not_for_replication"];
-                                lastid = (int)reader["object_id"];
-                                table.Constraints.Add(con);
+                                if (lastid != (int)reader["object_id"])
+                                {
+                                    con = new Constraint(table);
+                                    con.Id = (int)reader["object_id"];
+                                    con.Name = reader["Name"].ToString();
+                                    con.Type = Constraint.ConstraintType.ForeignKey;
+                                    con.WithNoCheck = (bool)reader["is_not_trusted"];
+                                    con.RelationalTableFullName = "[" + reader["ReferenceOwner"].ToString() + "].[" + reader["TableRelationalName"].ToString() + "]";
+                                    con.RelationalTableId = (int)reader["TableRelationalId"];
+                                    con.Owner = reader["Owner"].ToString();
+                                    con.IsDisabled = (bool)reader["is_disabled"];
+                                    con.OnDeleteCascade = (byte)reader["delete_referential_action"];
+                                    con.OnUpdateCascade = (byte)reader["update_referential_action"];
+                                    if (database.Options.Ignore.FilterNotForReplication)
+                                        con.NotForReplication = (bool)reader["is_not_for_replication"];
+                                    lastid = (int)reader["object_id"];
+                                    table.Constraints.Add(con);
+                                }
+                                ConstraintColumn ccon = new ConstraintColumn(con);
+                                ccon.Name = reader["ColumnName"].ToString();
+                                ccon.ColumnRelationalName = reader["ColumnRelationalName"].ToString();
+                                ccon.ColumnRelationalId = (int)reader["ColumnRelationalId"];
+                                ccon.Id = (int)reader["ColumnId"];
+                                ccon.KeyOrder = con.Columns.Count;
+                                ccon.ColumnRelationalDataTypeId = (int)reader["user_type_id"];
+                                //table.DependenciesCount++;
+                                con.Columns.Add(ccon);
                             }
-                            ConstraintColumn ccon = new ConstraintColumn(con);
-                            ccon.Name = reader["ColumnName"].ToString();
-                            ccon.ColumnRelationalName = reader["ColumnRelationalName"].ToString();
-                            ccon.ColumnRelationalId = (int)reader["ColumnRelationalId"];
-                            ccon.Id = (int)reader["ColumnId"];
-                            ccon.KeyOrder = con.Columns.Count;
-                            ccon.ColumnRelationalDataTypeId = (int)reader["user_type_id"];
-                            //table.DependenciesCount++;
-                            con.Columns.Add(ccon);
                         }
                     }
                 }
@@ -160,40 +167,44 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Generates
                             }
                             else
                                 change = false;
-                            if ((lastId != (int)reader["Index_id"]) || (change))
+
+                            if (table != null)
                             {
-                                con = new Constraint(table);
-                                con.Name = reader["Name"].ToString();
-                                con.Owner = (string)reader["Owner"];
-                                con.Id = (int)reader["Index_id"];
-                                con.Type = Constraint.ConstraintType.Unique;
-                                con.Index.Id = (int)reader["Index_id"];
-                                con.Index.AllowPageLocks = (bool)reader["allow_page_locks"];
-                                con.Index.AllowRowLocks = (bool)reader["allow_row_locks"];
-                                con.Index.FillFactor = (byte)reader["fill_factor"];
-                                con.Index.IgnoreDupKey = (bool)reader["ignore_dup_key"];
-                                con.Index.IsAutoStatistics = (bool)reader["ignore_dup_key"];
-                                con.Index.IsDisabled = (bool)reader["is_disabled"];
-                                con.Index.IsPadded = (bool)reader["is_padded"];
-                                con.Index.IsPrimaryKey = false;
-                                con.Index.IsUniqueKey = true;
-                                con.Index.Type = (Index.IndexTypeEnum)(byte)reader["type"];
-                                con.Index.Name = con.Name;
-                                if (database.Options.Ignore.FilterTableFileGroup)
-                                    con.Index.FileGroup = reader["FileGroup"].ToString();
-                                lastId = (int)reader["Index_id"];
-                                if (reader["ObjectType"].ToString().Trim().Equals("U"))
-                                    ((Table)table).Constraints.Add(con);
-                                else
-                                    ((TableType)table).Constraints.Add(con);
+                                if ((lastId != (int)reader["Index_id"]) || (change))
+                                {
+                                    con = new Constraint(table);
+                                    con.Name = reader["Name"].ToString();
+                                    con.Owner = (string)reader["Owner"];
+                                    con.Id = (int)reader["Index_id"];
+                                    con.Type = Constraint.ConstraintType.Unique;
+                                    con.Index.Id = (int)reader["Index_id"];
+                                    con.Index.AllowPageLocks = (bool)reader["allow_page_locks"];
+                                    con.Index.AllowRowLocks = (bool)reader["allow_row_locks"];
+                                    con.Index.FillFactor = (byte)reader["fill_factor"];
+                                    con.Index.IgnoreDupKey = (bool)reader["ignore_dup_key"];
+                                    con.Index.IsAutoStatistics = (bool)reader["ignore_dup_key"];
+                                    con.Index.IsDisabled = (bool)reader["is_disabled"];
+                                    con.Index.IsPadded = (bool)reader["is_padded"];
+                                    con.Index.IsPrimaryKey = false;
+                                    con.Index.IsUniqueKey = true;
+                                    con.Index.Type = (Index.IndexTypeEnum)(byte)reader["type"];
+                                    con.Index.Name = con.Name;
+                                    if (database.Options.Ignore.FilterTableFileGroup)
+                                        con.Index.FileGroup = reader["FileGroup"].ToString();
+                                    lastId = (int)reader["Index_id"];
+                                    if (reader["ObjectType"].ToString().Trim().Equals("U"))
+                                        ((Table)table).Constraints.Add(con);
+                                    else
+                                        ((TableType)table).Constraints.Add(con);
+                                }
+                                ConstraintColumn ccon = new ConstraintColumn(con);
+                                ccon.Name = reader["ColumnName"].ToString();
+                                ccon.IsIncluded = (bool)reader["is_included_column"];
+                                ccon.Order = (bool)reader["is_descending_key"];
+                                ccon.Id = (int)reader["column_id"];
+                                ccon.DataTypeId = (int)reader["user_type_id"];
+                                con.Columns.Add(ccon);
                             }
-                            ConstraintColumn ccon = new ConstraintColumn(con);
-                            ccon.Name = reader["ColumnName"].ToString();
-                            ccon.IsIncluded = (bool)reader["is_included_column"];
-                            ccon.Order = (bool)reader["is_descending_key"];
-                            ccon.Id = (int)reader["column_id"];
-                            ccon.DataTypeId = (int)reader["user_type_id"];
-                            con.Columns.Add(ccon);
                         }
                     }
                 }
@@ -231,41 +242,45 @@ namespace OpenDBDiff.Schema.SQLServer.Generates.Generates
                             }
                             else
                                 change = false;
-                            if ((lastId != (int)reader["Index_id"]) || (change))
+
+                            if (table != null)
                             {
-                                con = new Constraint(table);
-                                con.Id = (int)reader["Index_id"];
-                                con.Name = (string)reader["Name"];
-                                con.Owner = (string)reader["Owner"];
-                                con.Type = Constraint.ConstraintType.PrimaryKey;
-                                con.Index.Id = (int)reader["Index_id"];
-                                con.Index.AllowPageLocks = (bool)reader["allow_page_locks"];
-                                con.Index.AllowRowLocks = (bool)reader["allow_row_locks"];
-                                con.Index.FillFactor = (byte)reader["fill_factor"];
-                                con.Index.IgnoreDupKey = (bool)reader["ignore_dup_key"];
-                                con.Index.IsAutoStatistics = (bool)reader["ignore_dup_key"];
-                                con.Index.IsDisabled = (bool)reader["is_disabled"];
-                                con.Index.IsPadded = (bool)reader["is_padded"];
-                                con.Index.IsPrimaryKey = true;
-                                con.Index.IsUniqueKey = false;
-                                con.Index.Type = (Index.IndexTypeEnum)(byte)reader["type"];
-                                con.Index.Name = con.Name;
-                                if (database.Options.Ignore.FilterTableFileGroup)
-                                    con.Index.FileGroup = reader["FileGroup"].ToString();
-                                lastId = (int)reader["Index_id"];
-                                if (reader["ObjectType"].ToString().Trim().Equals("U"))
-                                    ((Table)table).Constraints.Add(con);
-                                else
-                                    ((TableType)table).Constraints.Add(con);
+                                if ((lastId != (int)reader["Index_id"]) || (change)) 
+                                {
+                                    con = new Constraint(table);
+                                    con.Id = (int)reader["Index_id"];
+                                    con.Name = (string)reader["Name"];
+                                    con.Owner = (string)reader["Owner"];
+                                    con.Type = Constraint.ConstraintType.PrimaryKey;
+                                    con.Index.Id = (int)reader["Index_id"];
+                                    con.Index.AllowPageLocks = (bool)reader["allow_page_locks"];
+                                    con.Index.AllowRowLocks = (bool)reader["allow_row_locks"];
+                                    con.Index.FillFactor = (byte)reader["fill_factor"];
+                                    con.Index.IgnoreDupKey = (bool)reader["ignore_dup_key"];
+                                    con.Index.IsAutoStatistics = (bool)reader["ignore_dup_key"];
+                                    con.Index.IsDisabled = (bool)reader["is_disabled"];
+                                    con.Index.IsPadded = (bool)reader["is_padded"];
+                                    con.Index.IsPrimaryKey = true;
+                                    con.Index.IsUniqueKey = false;
+                                    con.Index.Type = (Index.IndexTypeEnum)(byte)reader["type"];
+                                    con.Index.Name = con.Name;
+                                    if (database.Options.Ignore.FilterTableFileGroup)
+                                        con.Index.FileGroup = reader["FileGroup"].ToString();
+                                    lastId = (int)reader["Index_id"];
+                                    if (reader["ObjectType"].ToString().Trim().Equals("U"))
+                                        ((Table)table).Constraints.Add(con);
+                                    else
+                                        ((TableType)table).Constraints.Add(con);
+                                }
+                                ConstraintColumn ccon = new ConstraintColumn(con);
+                                ccon.Name = (string)reader["ColumnName"];
+                                ccon.IsIncluded = (bool)reader["is_included_column"];
+                                ccon.Order = (bool)reader["is_descending_key"];
+                                ccon.KeyOrder = (byte)reader["key_ordinal"];
+                                ccon.Id = (int)reader["column_id"];
+                                ccon.DataTypeId = (int)reader["user_type_id"];
+                                con.Columns.Add(ccon);
                             }
-                            ConstraintColumn ccon = new ConstraintColumn(con);
-                            ccon.Name = (string)reader["ColumnName"];
-                            ccon.IsIncluded = (bool)reader["is_included_column"];
-                            ccon.Order = (bool)reader["is_descending_key"];
-                            ccon.KeyOrder = (byte)reader["key_ordinal"];
-                            ccon.Id = (int)reader["column_id"];
-                            ccon.DataTypeId = (int)reader["user_type_id"];
-                            con.Columns.Add(ccon);
                         }
                     }
                 }


### PR DESCRIPTION
...constraint list contains references to table(s) that are filtered out of the comparison

Repro steps:

1. Use the script [here](https://gist.github.com/edharper01/94764c0a6e0c0a375f78212d4fcd668a.js) build two databases with identical DDL - **obdb** and **odbd2** - on a SQL Server instance
2. Start OpenDBDiff.exe and set up **odbd** at the source database and **odbd2** as the target database
3. Create an exclusion filter to exclude the schema **b** (in Options > Exclude by name)
4. Run the comparison. 

Expected behaviour: no differences should be reported.

Actual behaviour: **[c].[test]** is reported as having differences - PK, FK, and check constraints are missing.

This PR addresses the issue by skipping an attempt to script constraints when the parent table is filtered out.  