### PR TITLE
Fix issue where trigger generation aborts because parent object matches a filter

### DIFF
--- a/OpenDBDiff.SqlServer.Schema/Generates/GenerateTriggers.cs
+++ b/OpenDBDiff.SqlServer.Schema/Generates/GenerateTriggers.cs
@@ -61,6 +61,7 @@ namespace OpenDBDiff.SqlServer.Schema.Generates
                                         else
                                             parent = database.Tables.Find(parentId);
                                     }
+                                    if (parent == null) { continue; }
                                     if (reader["type"].Equals("TR"))
                                     {
                                         Trigger item = new Trigger(parent);


### PR DESCRIPTION
Extends fix in commit 1e7721a - this change resolves a problem in trigger comparison aborts if the parent object ID is not found because it is filtered.