### PR TITLE
Fix UI threading errors; clean up settings

### DIFF
--- a/OpenDBDiff.SqlServer.Schema/Compare/CompareBase.cs
+++ b/OpenDBDiff.SqlServer.Schema/Compare/CompareBase.cs
@@ -43,18 +43,19 @@ namespace OpenDBDiff.SqlServer.Schema.Compare
                 if (destinationCount > destinationIndex)
                 {
                     node = destinationFields[destinationIndex];
-                    Generate.RaiseOnCompareProgress("Comparing Destination {0}: [{1}]", node.ObjectType, node.Name);
+                    Generate.RaiseOnCompareProgress(CompareProgress.Value, "Comparing Destination {0}: [{1}]", node.ObjectType, node.Name);
                     if (!originFields.Contains(node.FullName))
                     {
-                        Generate.RaiseOnCompareProgress("Adding {0}: [{1}]", node.ObjectType, node.Name);
+                        Generate.RaiseOnCompareProgress(CompareProgress.Value, "Adding {0}: [{1}]", node.ObjectType, node.Name);
                         DoNew<Root>(originFields, node);
                     }
                     else
                     {
-                        Generate.RaiseOnCompareProgress("Updating {0}: [{1}]", node.ObjectType, node.Name);
+                        Generate.RaiseOnCompareProgress(CompareProgress.Value, "Updating {0}: [{1}]", node.ObjectType, node.Name);
                         DoUpdate<Root>(originFields, node);
                     }
 
+                    CompareProgress.Value++;
                     destinationIndex++;
                     has = true;
                 }
@@ -62,13 +63,14 @@ namespace OpenDBDiff.SqlServer.Schema.Compare
                 if (originCount > originIndex)
                 {
                     node = originFields[originIndex];
-                    Generate.RaiseOnCompareProgress("Comparing Source {0}: [{1}]", node.ObjectType, node.Name);
+                    Generate.RaiseOnCompareProgress(CompareProgress.Value, "Comparing Source {0}: [{1}]", node.ObjectType, node.Name);
                     if (!destinationFields.Contains(node.FullName))
                     {
-                        Generate.RaiseOnCompareProgress("Deleting {0}: [{1}]", node.ObjectType, node.Name);
+                        Generate.RaiseOnCompareProgress(CompareProgress.Value, "Deleting {0}: [{1}]", node.ObjectType, node.Name);
                         DoDelete(node);
                     }
 
+                    CompareProgress.Value++;
                     originIndex++;
                     has = true;
                 }

--- a/OpenDBDiff.SqlServer.Schema/Compare/CompareProgress.cs
+++ b/OpenDBDiff.SqlServer.Schema/Compare/CompareProgress.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenDBDiff.SqlServer.Schema.Compare
+{
+    public static class CompareProgress
+    {
+        public static int Value { get; set; } = 0;
+    }
+}

--- a/OpenDBDiff.SqlServer.Schema/Generates/Generate.cs
+++ b/OpenDBDiff.SqlServer.Schema/Generates/Generate.cs
@@ -8,6 +8,7 @@ using OpenDBDiff.SqlServer.Schema.Options;
 using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
+using System.Threading;
 
 namespace OpenDBDiff.SqlServer.Schema.Generates
 {
@@ -15,11 +16,13 @@ namespace OpenDBDiff.SqlServer.Schema.Generates
     {
         private readonly List<MessageLog> messages;
         private ProgressEventArgs currentlyReading;
+        private SynchronizationContext syncContext;
 
         public Generate()
         {
             messages = new List<MessageLog>();
             OnReading += Generate_OnReading;
+            syncContext = SynchronizationContext.Current;
         }
 
         public static int MaxValue
@@ -56,7 +59,11 @@ namespace OpenDBDiff.SqlServer.Schema.Generates
         public void RaiseOnReading(ProgressEventArgs e)
         {
             this.currentlyReading = e;
-            if (OnReading != null) OnReading(e);
+
+            if (OnReading != null)
+            {
+                syncContext.Post(state => OnReading((ProgressEventArgs)state), e);
+            }
         }
 
         public void RaiseOnReadingOne(object name)
@@ -81,77 +88,62 @@ namespace OpenDBDiff.SqlServer.Schema.Generates
             databaseSchema.Options = Options;
             databaseSchema.Name = Name;
             databaseSchema.Info = (new GenerateDatabase(ConnectionString, Options)).Get(databaseSchema);
-            /*Thread t1 = new Thread(delegate()
-                {
-                    try
-                    {*/
-            (new GenerateRules(this)).Fill(databaseSchema, ConnectionString);
-            (new GenerateTables(this)).Fill(databaseSchema, ConnectionString, messages);
-            (new GenerateViews(this)).Fill(databaseSchema, ConnectionString, messages);
 
-            if (Options.Ignore.FilterIndex)
-            {
-                (new GenerateIndex(this)).Fill(databaseSchema, ConnectionString);
-                (new GenerateFullTextIndex(this)).Fill(databaseSchema, ConnectionString);
-            }
+            //0
+            (new GenerateRules(this)).Fill(databaseSchema, ConnectionString);
+            //1 & 2
+            (new GenerateTables(this)).Fill(databaseSchema, ConnectionString, messages);
+            //3
             (new GenerateUserDataTypes(this)).Fill(databaseSchema, ConnectionString, messages);
+            //4
             (new GenerateXMLSchemas(this)).Fill(databaseSchema, ConnectionString);
+            //5
             (new GenerateSchemas(this)).Fill(databaseSchema, ConnectionString);
-            /*}
-                    catch (Exception ex)
-                    {
-                        error = ex.StackTrace;
-                    }
-                });
-                Thread t2 = new Thread(delegate()
-                {
-                    try
-                    {*/
+            //6
+            (new GenerateUsers(this)).Fill(databaseSchema, ConnectionString);
 
             //not supported in azure yet
             if (databaseSchema.Info.Version != DatabaseInfo.SQLServerVersion.SQLServerAzure10)
             {
+                //7
                 (new GeneratePartitionFunctions(this)).Fill(databaseSchema, ConnectionString);
+                //8
                 (new GeneratePartitionScheme(this)).Fill(databaseSchema, ConnectionString);
+                //9
                 (new GenerateFileGroups(this)).Fill(databaseSchema, ConnectionString);
             }
 
+            //10
             (new GenerateDDLTriggers(this)).Fill(databaseSchema, ConnectionString);
+            //11
             (new GenerateSynonyms(this)).Fill(databaseSchema, ConnectionString);
 
             //not supported in azure yet
             if (databaseSchema.Info.Version != DatabaseInfo.SQLServerVersion.SQLServerAzure10)
             {
+                //12
                 (new GenerateAssemblies(this)).Fill(databaseSchema, ConnectionString);
+                //
                 (new GenerateFullText(this)).Fill(databaseSchema, ConnectionString);
             }
-            /*}
-                    catch (Exception ex)
-                    {
-                        error = ex.StackTrace;
-                    }
-                });
-                Thread t3 = new Thread(delegate()
-                {
-                    try
-                    {*/
+
+            //13
             (new GenerateStoredProcedures(this)).Fill(databaseSchema, ConnectionString);
+            //14
+            (new GenerateViews(this)).Fill(databaseSchema, ConnectionString, messages);
+            //15
             (new GenerateFunctions(this)).Fill(databaseSchema, ConnectionString);
+            //16
+            if (Options.Ignore.FilterIndex)
+            {
+                (new GenerateIndex(this)).Fill(databaseSchema, ConnectionString);
+                (new GenerateFullTextIndex(this)).Fill(databaseSchema, ConnectionString);
+            }
+            //17
             (new GenerateTriggers(this)).Fill(databaseSchema, ConnectionString, messages);
+            //18
             (new GenerateTextObjects(this)).Fill(databaseSchema, ConnectionString);
-            (new GenerateUsers(this)).Fill(databaseSchema, ConnectionString);
-            /*}
-                    catch (Exception ex)
-                    {
-                        error = ex.StackTrace;
-                    }
-                });
-                t1.Start();
-                t2.Start();
-                t3.Start();
-                t1.Join();
-                t2.Join();
-                t3.Join();*/
+
             if (String.IsNullOrEmpty(error))
             {
                 /*Las propiedades extendidas deben ir despues de haber capturado el resto de los objetos de la base*/

--- a/OpenDBDiff.SqlServer.Schema/Generates/Generate.cs
+++ b/OpenDBDiff.SqlServer.Schema/Generates/Generate.cs
@@ -158,14 +158,15 @@ namespace OpenDBDiff.SqlServer.Schema.Generates
         private void tables_OnTableProgress(object sender, ProgressEventArgs e)
         {
             ProgressEventHandler.RaiseOnChange(e);
+            OnCompareProgress?.Invoke(e); // Raise the OnCompareProgress event
         }
 
         // TODO: Static because Compare method is static; static events are not my favorite
         public static event ProgressEventHandler.ProgressHandler OnCompareProgress;
 
-        internal static void RaiseOnCompareProgress(string formatString, params object[] formatParams)
+        internal static void RaiseOnCompareProgress(int value, string formatString, params object[] formatParams)
         {
-            OnCompareProgress?.Invoke(new ProgressEventArgs(String.Format(formatString, formatParams), -1));
+            OnCompareProgress?.Invoke(new ProgressEventArgs(String.Format(formatString, formatParams), value));
         }
 
         /// <summary>

--- a/OpenDBDiff.SqlServer.Schema/OpenDBDiff.SqlServer.Schema.csproj
+++ b/OpenDBDiff.SqlServer.Schema/OpenDBDiff.SqlServer.Schema.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Compare\CompareIndexes.cs" />
     <Compile Include="Compare\ComparePartitionFunction.cs" />
     <Compile Include="Compare\ComparePartitionSchemes.cs" />
+    <Compile Include="Compare\CompareProgress.cs" />
     <Compile Include="Compare\CompareRoles.cs" />
     <Compile Include="Compare\CompareRules.cs" />
     <Compile Include="Compare\CompareSchemas.cs" />

--- a/OpenDBDiff.SqlServer.Schema/Options/SqlOptionIgnore.cs
+++ b/OpenDBDiff.SqlServer.Schema/Options/SqlOptionIgnore.cs
@@ -1,6 +1,7 @@
 using OpenDBDiff.Abstractions.Schema.Model;
 using System;
 using System.Collections.Generic;
+using System.Security.AccessControl;
 
 namespace OpenDBDiff.SqlServer.Schema.Options
 {
@@ -8,6 +9,8 @@ namespace OpenDBDiff.SqlServer.Schema.Options
     {
         public SqlOptionIgnore(bool defaultValue)
         {
+            FilterSecurity = true;
+            FilterProgrammability = true;
             FilterPartitionFunction = true;
             FilterPartitionScheme = true;
             FilterIndexFilter = true;
@@ -28,6 +31,7 @@ namespace OpenDBDiff.SqlServer.Schema.Options
             FilterCLRFunction = true;
             FilterCLRTrigger = true;
             FilterCLRUDT = true;
+            FilterCLRAggregates = true;
             FilterCLRStoredProcedure = true;
             FilterFullText = true;
             FilterFullTextPath = false;
@@ -49,11 +53,14 @@ namespace OpenDBDiff.SqlServer.Schema.Options
             FilterSynonyms = defaultValue;
             FilterRules = defaultValue;
             FilterAssemblies = defaultValue;
+            FilterPermissions = defaultValue;
         }
 
         public SqlOptionIgnore(IOptionsContainer<bool> optionsContainer)
         {
             var options = optionsContainer.GetOptions();
+            FilterSecurity = options["FilterSecurity"];
+            FilterProgrammability = options["FilterProgrammability"];
             FilterPartitionFunction = options["FilterPartitionFunction"];
             FilterPartitionScheme = options["FilterPartitionScheme"];
             FilterIndexFilter = options["FilterIndexFilter"];
@@ -74,6 +81,7 @@ namespace OpenDBDiff.SqlServer.Schema.Options
             FilterCLRFunction = options["FilterCLRFunction"];
             FilterCLRTrigger = options["FilterCLRTrigger"];
             FilterCLRUDT = options["FilterCLRUDT"];
+            FilterCLRAggregates = options["FilterCLRAggregates"];
             FilterCLRStoredProcedure = options["FilterCLRStoredProcedure"];
             FilterFullText = options["FilterFullText"];
             FilterFullTextPath = options["FilterFullTextPath"];
@@ -95,7 +103,7 @@ namespace OpenDBDiff.SqlServer.Schema.Options
             FilterSynonyms = options["FilterSynonyms"];
             FilterRules = options["FilterRules"];
             FilterAssemblies = options["FilterAssemblies"];
-
+            FilterPermissions = options["FilterPermissions"];
         }
 
         public Boolean FilterTableChangeTracking { get; set; }
@@ -109,6 +117,8 @@ namespace OpenDBDiff.SqlServer.Schema.Options
         public Boolean FilterCLRStoredProcedure { get; set; }
 
         public Boolean FilterCLRUDT { get; set; }
+
+        public Boolean FilterCLRAggregates { get; set; }
 
         public Boolean FilterCLRTrigger { get; set; }
 
@@ -133,6 +143,8 @@ namespace OpenDBDiff.SqlServer.Schema.Options
         public Boolean FilterIndexFillFactor { get; set; }
 
         public Boolean FilterAssemblies { get; set; }
+
+        public Boolean FilterPermissions { get; set; }
 
         public Boolean FilterRules { get; set; }
 
@@ -178,12 +190,18 @@ namespace OpenDBDiff.SqlServer.Schema.Options
 
         public Boolean FilterPartitionScheme { get; set; }
 
+        public Boolean FilterProgrammability { get; set; }
+
         public Boolean FilterPartitionFunction { get; set; }
+
+        public Boolean FilterSecurity { get; set; }
 
         public IDictionary<string, bool> GetOptions()
         {
 
             Dictionary<string, bool> options = new Dictionary<string, bool>();
+            options.Add("FilterSecurity", FilterSecurity);
+            options.Add("FilterProgrammability", FilterProgrammability);
             options.Add("FilterPartitionFunction", FilterPartitionFunction);
             options.Add("FilterPartitionScheme", FilterPartitionScheme);
             options.Add("FilterIndexFilter", FilterIndexFilter);
@@ -205,6 +223,7 @@ namespace OpenDBDiff.SqlServer.Schema.Options
             options.Add("FilterCLRTrigger", FilterCLRTrigger);
             options.Add("FilterCLRUDT", FilterCLRUDT);
             options.Add("FilterCLRStoredProcedure", FilterCLRStoredProcedure);
+            options.Add("FilterCLRAggregates", FilterCLRAggregates);
             options.Add("FilterFullText", FilterFullText);
             options.Add("FilterFullTextPath", FilterFullTextPath);
             options.Add("FilterTableLockEscalation", FilterTableLockEscalation);
@@ -225,6 +244,7 @@ namespace OpenDBDiff.SqlServer.Schema.Options
             options.Add("FilterSynonyms", FilterSynonyms);
             options.Add("FilterRules", FilterRules);
             options.Add("FilterAssemblies", FilterAssemblies);
+            options.Add("FilterPermissions", FilterPermissions);
             return options;
         }
     }

--- a/OpenDBDiff.SqlServer.Ui/Front/SqlOptionsFront.Designer.cs
+++ b/OpenDBDiff.SqlServer.Ui/Front/SqlOptionsFront.Designer.cs
@@ -37,9 +37,9 @@ namespace OpenDBDiff.SqlServer.Ui
             this.chkConstraintsUK = new System.Windows.Forms.CheckBox();
             this.chkConstraintsFK = new System.Windows.Forms.CheckBox();
             this.chkConstraintsPK = new System.Windows.Forms.CheckBox();
-            this.checkBox5 = new System.Windows.Forms.CheckBox();
-            this.checkPartitionFunction = new System.Windows.Forms.CheckBox();
-            this.checkBox4 = new System.Windows.Forms.CheckBox();
+            this.chkPartitionSchemas = new System.Windows.Forms.CheckBox();
+            this.chkPartitionFunction = new System.Windows.Forms.CheckBox();
+            this.chkCompCLRAggregates = new System.Windows.Forms.CheckBox();
             this.chkCompCLRUDT = new System.Windows.Forms.CheckBox();
             this.chkCompCLRFunctions = new System.Windows.Forms.CheckBox();
             this.chkCompCLRTrigger = new System.Windows.Forms.CheckBox();
@@ -63,11 +63,11 @@ namespace OpenDBDiff.SqlServer.Ui
             this.chkIndex = new System.Windows.Forms.CheckBox();
             this.chkTableOption = new System.Windows.Forms.CheckBox();
             this.chkCompXMLSchemas = new System.Windows.Forms.CheckBox();
-            this.chkCompFunciones = new System.Windows.Forms.CheckBox();
+            this.chkCompFunctions = new System.Windows.Forms.CheckBox();
             this.chkCompStoredProcedure = new System.Windows.Forms.CheckBox();
             this.chkTables = new System.Windows.Forms.CheckBox();
             this.chkCompTriggers = new System.Windows.Forms.CheckBox();
-            this.chkCompVistas = new System.Windows.Forms.CheckBox();
+            this.chkCompViews = new System.Windows.Forms.CheckBox();
             this.chkCompExtendedProperties = new System.Windows.Forms.CheckBox();
             this.txtXML = new System.Windows.Forms.TextBox();
             this.label10 = new System.Windows.Forms.Label();
@@ -92,9 +92,10 @@ namespace OpenDBDiff.SqlServer.Ui
             this.gradientPanel6 = new System.Windows.Forms.Panel();
             this.chkIgnoreNotForReplication = new System.Windows.Forms.CheckBox();
             this.gradientPanel5 = new System.Windows.Forms.Panel();
+            this.chkCompSynonyms = new System.Windows.Forms.CheckBox();
             this.gradientPanel4 = new System.Windows.Forms.Panel();
             this.gradientPanel3 = new System.Windows.Forms.Panel();
-            this.checkBox1 = new System.Windows.Forms.CheckBox();
+            this.chkCompPermissions = new System.Windows.Forms.CheckBox();
             this.gradientPanel2 = new System.Windows.Forms.Panel();
             this.chkTableChangeTracking = new System.Windows.Forms.CheckBox();
             this.chkTableLockEscalation = new System.Windows.Forms.CheckBox();
@@ -137,7 +138,8 @@ namespace OpenDBDiff.SqlServer.Ui
             this.rdoCaseAutomatic = new System.Windows.Forms.RadioButton();
             this.rdoCaseInsensitive = new System.Windows.Forms.RadioButton();
             this.chkReloadDB = new System.Windows.Forms.CheckBox();
-            this.IncludeSynonymsCheckBox = new System.Windows.Forms.CheckBox();
+            this.chkCompSecurity = new System.Windows.Forms.CheckBox();
+            this.chkCompProgrammability = new System.Windows.Forms.CheckBox();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
             this.gradientPanel6.SuspendLayout();
@@ -169,7 +171,7 @@ namespace OpenDBDiff.SqlServer.Ui
             this.chkFullTextPath.Checked = true;
             this.chkFullTextPath.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkFullTextPath.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.chkFullTextPath.Location = new System.Drawing.Point(28, 44);
+            this.chkFullTextPath.Location = new System.Drawing.Point(46, 63);
             this.chkFullTextPath.Name = "chkFullTextPath";
             this.chkFullTextPath.Size = new System.Drawing.Size(85, 17);
             this.chkFullTextPath.TabIndex = 36;
@@ -241,44 +243,44 @@ namespace OpenDBDiff.SqlServer.Ui
             this.chkConstraintsPK.Text = "Primary key";
             this.chkConstraintsPK.UseVisualStyleBackColor = true;
             // 
-            // checkBox5
+            // chkPartitionSchemas
             // 
-            this.checkBox5.AutoSize = true;
-            this.checkBox5.Checked = true;
-            this.checkBox5.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBox5.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.checkBox5.Location = new System.Drawing.Point(13, 75);
-            this.checkBox5.Name = "checkBox5";
-            this.checkBox5.Size = new System.Drawing.Size(109, 17);
-            this.checkBox5.TabIndex = 27;
-            this.checkBox5.Text = "Partition schemas";
-            this.checkBox5.UseVisualStyleBackColor = true;
+            this.chkPartitionSchemas.AutoSize = true;
+            this.chkPartitionSchemas.Checked = true;
+            this.chkPartitionSchemas.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkPartitionSchemas.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.chkPartitionSchemas.Location = new System.Drawing.Point(33, 97);
+            this.chkPartitionSchemas.Name = "chkPartitionSchemas";
+            this.chkPartitionSchemas.Size = new System.Drawing.Size(109, 17);
+            this.chkPartitionSchemas.TabIndex = 27;
+            this.chkPartitionSchemas.Text = "Partition schemas";
+            this.chkPartitionSchemas.UseVisualStyleBackColor = true;
             // 
-            // checkPartitionFunction
+            // chkPartitionFunction
             // 
-            this.checkPartitionFunction.AutoSize = true;
-            this.checkPartitionFunction.Checked = true;
-            this.checkPartitionFunction.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkPartitionFunction.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.checkPartitionFunction.Location = new System.Drawing.Point(13, 52);
-            this.checkPartitionFunction.Name = "checkPartitionFunction";
-            this.checkPartitionFunction.Size = new System.Drawing.Size(110, 17);
-            this.checkPartitionFunction.TabIndex = 26;
-            this.checkPartitionFunction.Text = "Partition functions";
-            this.checkPartitionFunction.UseVisualStyleBackColor = true;
+            this.chkPartitionFunction.AutoSize = true;
+            this.chkPartitionFunction.Checked = true;
+            this.chkPartitionFunction.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkPartitionFunction.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.chkPartitionFunction.Location = new System.Drawing.Point(33, 74);
+            this.chkPartitionFunction.Name = "chkPartitionFunction";
+            this.chkPartitionFunction.Size = new System.Drawing.Size(110, 17);
+            this.chkPartitionFunction.TabIndex = 26;
+            this.chkPartitionFunction.Text = "Partition functions";
+            this.chkPartitionFunction.UseVisualStyleBackColor = true;
             // 
-            // checkBox4
+            // chkCompCLRAggregates
             // 
-            this.checkBox4.AutoSize = true;
-            this.checkBox4.Checked = true;
-            this.checkBox4.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBox4.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.checkBox4.Location = new System.Drawing.Point(28, 27);
-            this.checkBox4.Name = "checkBox4";
-            this.checkBox4.Size = new System.Drawing.Size(103, 17);
-            this.checkBox4.TabIndex = 35;
-            this.checkBox4.Text = "CLR aggregates";
-            this.checkBox4.UseVisualStyleBackColor = true;
+            this.chkCompCLRAggregates.AutoSize = true;
+            this.chkCompCLRAggregates.Checked = true;
+            this.chkCompCLRAggregates.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkCompCLRAggregates.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.chkCompCLRAggregates.Location = new System.Drawing.Point(28, 27);
+            this.chkCompCLRAggregates.Name = "chkCompCLRAggregates";
+            this.chkCompCLRAggregates.Size = new System.Drawing.Size(103, 17);
+            this.chkCompCLRAggregates.TabIndex = 35;
+            this.chkCompCLRAggregates.Text = "CLR aggregates";
+            this.chkCompCLRAggregates.UseVisualStyleBackColor = true;
             // 
             // chkCompCLRUDT
             // 
@@ -351,7 +353,7 @@ namespace OpenDBDiff.SqlServer.Ui
             this.chkFullText.Checked = true;
             this.chkFullText.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkFullText.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.chkFullText.Location = new System.Drawing.Point(10, 25);
+            this.chkFullText.Location = new System.Drawing.Point(28, 44);
             this.chkFullText.Name = "chkFullText";
             this.chkFullText.Size = new System.Drawing.Size(62, 17);
             this.chkFullText.TabIndex = 29;
@@ -365,7 +367,7 @@ namespace OpenDBDiff.SqlServer.Ui
             this.chkCompRules.Checked = true;
             this.chkCompRules.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkCompRules.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.chkCompRules.Location = new System.Drawing.Point(13, 98);
+            this.chkCompRules.Location = new System.Drawing.Point(33, 120);
             this.chkCompRules.Name = "chkCompRules";
             this.chkCompRules.Size = new System.Drawing.Size(53, 17);
             this.chkCompRules.TabIndex = 22;
@@ -378,7 +380,7 @@ namespace OpenDBDiff.SqlServer.Ui
             this.chkCompRoles.Checked = true;
             this.chkCompRoles.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkCompRoles.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.chkCompRoles.Location = new System.Drawing.Point(10, 82);
+            this.chkCompRoles.Location = new System.Drawing.Point(28, 101);
             this.chkCompRoles.Name = "chkCompRoles";
             this.chkCompRoles.Size = new System.Drawing.Size(53, 17);
             this.chkCompRoles.TabIndex = 28;
@@ -391,7 +393,7 @@ namespace OpenDBDiff.SqlServer.Ui
             this.chkCompUsers.Checked = true;
             this.chkCompUsers.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkCompUsers.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.chkCompUsers.Location = new System.Drawing.Point(10, 63);
+            this.chkCompUsers.Location = new System.Drawing.Point(28, 82);
             this.chkCompUsers.Name = "chkCompUsers";
             this.chkCompUsers.Size = new System.Drawing.Size(53, 17);
             this.chkCompUsers.TabIndex = 23;
@@ -417,7 +419,7 @@ namespace OpenDBDiff.SqlServer.Ui
             this.chkCompTriggersDDL.Checked = true;
             this.chkCompTriggersDDL.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkCompTriggersDDL.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.chkCompTriggersDDL.Location = new System.Drawing.Point(13, 6);
+            this.chkCompTriggersDDL.Location = new System.Drawing.Point(33, 28);
             this.chkCompTriggersDDL.Name = "chkCompTriggersDDL";
             this.chkCompTriggersDDL.Size = new System.Drawing.Size(85, 17);
             this.chkCompTriggersDDL.TabIndex = 19;
@@ -471,7 +473,7 @@ namespace OpenDBDiff.SqlServer.Ui
             this.chkFileGroups.Checked = true;
             this.chkFileGroups.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkFileGroups.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.chkFileGroups.Location = new System.Drawing.Point(10, 6);
+            this.chkFileGroups.Location = new System.Drawing.Point(28, 25);
             this.chkFileGroups.Name = "chkFileGroups";
             this.chkFileGroups.Size = new System.Drawing.Size(77, 17);
             this.chkFileGroups.TabIndex = 25;
@@ -525,7 +527,7 @@ namespace OpenDBDiff.SqlServer.Ui
             this.chkCompSchemas.Checked = true;
             this.chkCompSchemas.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkCompSchemas.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.chkCompSchemas.Location = new System.Drawing.Point(10, 101);
+            this.chkCompSchemas.Location = new System.Drawing.Point(28, 120);
             this.chkCompSchemas.Name = "chkCompSchemas";
             this.chkCompSchemas.Size = new System.Drawing.Size(70, 17);
             this.chkCompSchemas.TabIndex = 24;
@@ -538,7 +540,7 @@ namespace OpenDBDiff.SqlServer.Ui
             this.chkCompUDT.Checked = true;
             this.chkCompUDT.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkCompUDT.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.chkCompUDT.Location = new System.Drawing.Point(13, 190);
+            this.chkCompUDT.Location = new System.Drawing.Point(33, 212);
             this.chkCompUDT.Name = "chkCompUDT";
             this.chkCompUDT.Size = new System.Drawing.Size(100, 17);
             this.chkCompUDT.TabIndex = 20;
@@ -579,25 +581,25 @@ namespace OpenDBDiff.SqlServer.Ui
             this.chkCompXMLSchemas.Checked = true;
             this.chkCompXMLSchemas.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkCompXMLSchemas.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.chkCompXMLSchemas.Location = new System.Drawing.Point(13, 236);
+            this.chkCompXMLSchemas.Location = new System.Drawing.Point(33, 258);
             this.chkCompXMLSchemas.Name = "chkCompXMLSchemas";
             this.chkCompXMLSchemas.Size = new System.Drawing.Size(93, 17);
             this.chkCompXMLSchemas.TabIndex = 21;
             this.chkCompXMLSchemas.Text = "XML schemas";
             this.chkCompXMLSchemas.UseVisualStyleBackColor = true;
             // 
-            // chkCompFunciones
+            // chkCompFunctions
             // 
-            this.chkCompFunciones.AutoSize = true;
-            this.chkCompFunciones.Checked = true;
-            this.chkCompFunciones.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkCompFunciones.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.chkCompFunciones.Location = new System.Drawing.Point(13, 29);
-            this.chkCompFunciones.Name = "chkCompFunciones";
-            this.chkCompFunciones.Size = new System.Drawing.Size(72, 17);
-            this.chkCompFunciones.TabIndex = 15;
-            this.chkCompFunciones.Text = "Functions";
-            this.chkCompFunciones.UseVisualStyleBackColor = true;
+            this.chkCompFunctions.AutoSize = true;
+            this.chkCompFunctions.Checked = true;
+            this.chkCompFunctions.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkCompFunctions.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.chkCompFunctions.Location = new System.Drawing.Point(33, 51);
+            this.chkCompFunctions.Name = "chkCompFunctions";
+            this.chkCompFunctions.Size = new System.Drawing.Size(72, 17);
+            this.chkCompFunctions.TabIndex = 15;
+            this.chkCompFunctions.Text = "Functions";
+            this.chkCompFunctions.UseVisualStyleBackColor = true;
             // 
             // chkCompStoredProcedure
             // 
@@ -605,7 +607,7 @@ namespace OpenDBDiff.SqlServer.Ui
             this.chkCompStoredProcedure.Checked = true;
             this.chkCompStoredProcedure.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkCompStoredProcedure.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.chkCompStoredProcedure.Location = new System.Drawing.Point(13, 121);
+            this.chkCompStoredProcedure.Location = new System.Drawing.Point(33, 143);
             this.chkCompStoredProcedure.Name = "chkCompStoredProcedure";
             this.chkCompStoredProcedure.Size = new System.Drawing.Size(113, 17);
             this.chkCompStoredProcedure.TabIndex = 16;
@@ -633,25 +635,25 @@ namespace OpenDBDiff.SqlServer.Ui
             this.chkCompTriggers.Checked = true;
             this.chkCompTriggers.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkCompTriggers.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.chkCompTriggers.Location = new System.Drawing.Point(13, 167);
+            this.chkCompTriggers.Location = new System.Drawing.Point(33, 189);
             this.chkCompTriggers.Name = "chkCompTriggers";
             this.chkCompTriggers.Size = new System.Drawing.Size(64, 17);
             this.chkCompTriggers.TabIndex = 18;
             this.chkCompTriggers.Text = "Triggers";
             this.chkCompTriggers.UseVisualStyleBackColor = true;
             // 
-            // chkCompVistas
+            // chkCompViews
             // 
-            this.chkCompVistas.AutoSize = true;
-            this.chkCompVistas.Checked = true;
-            this.chkCompVistas.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkCompVistas.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.chkCompVistas.Location = new System.Drawing.Point(13, 213);
-            this.chkCompVistas.Name = "chkCompVistas";
-            this.chkCompVistas.Size = new System.Drawing.Size(54, 17);
-            this.chkCompVistas.TabIndex = 17;
-            this.chkCompVistas.Text = "Views";
-            this.chkCompVistas.UseVisualStyleBackColor = true;
+            this.chkCompViews.AutoSize = true;
+            this.chkCompViews.Checked = true;
+            this.chkCompViews.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkCompViews.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.chkCompViews.Location = new System.Drawing.Point(33, 235);
+            this.chkCompViews.Name = "chkCompViews";
+            this.chkCompViews.Size = new System.Drawing.Size(54, 17);
+            this.chkCompViews.TabIndex = 17;
+            this.chkCompViews.Text = "Views";
+            this.chkCompViews.UseVisualStyleBackColor = true;
             // 
             // chkCompExtendedProperties
             // 
@@ -881,11 +883,12 @@ namespace OpenDBDiff.SqlServer.Ui
             // 
             // gradientPanel5
             // 
-            this.gradientPanel5.Controls.Add(this.IncludeSynonymsCheckBox);
-            this.gradientPanel5.Controls.Add(this.checkBox5);
-            this.gradientPanel5.Controls.Add(this.chkCompFunciones);
-            this.gradientPanel5.Controls.Add(this.checkPartitionFunction);
-            this.gradientPanel5.Controls.Add(this.chkCompVistas);
+            this.gradientPanel5.Controls.Add(this.chkCompProgrammability);
+            this.gradientPanel5.Controls.Add(this.chkCompSynonyms);
+            this.gradientPanel5.Controls.Add(this.chkPartitionSchemas);
+            this.gradientPanel5.Controls.Add(this.chkCompFunctions);
+            this.gradientPanel5.Controls.Add(this.chkPartitionFunction);
+            this.gradientPanel5.Controls.Add(this.chkCompViews);
             this.gradientPanel5.Controls.Add(this.chkCompRules);
             this.gradientPanel5.Controls.Add(this.chkCompTriggers);
             this.gradientPanel5.Controls.Add(this.chkCompTriggersDDL);
@@ -897,22 +900,36 @@ namespace OpenDBDiff.SqlServer.Ui
             this.gradientPanel5.Size = new System.Drawing.Size(171, 338);
             this.gradientPanel5.TabIndex = 6;
             // 
+            // chkCompSynonyms
+            // 
+            this.chkCompSynonyms.AutoSize = true;
+            this.chkCompSynonyms.Checked = true;
+            this.chkCompSynonyms.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkCompSynonyms.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.chkCompSynonyms.Location = new System.Drawing.Point(33, 166);
+            this.chkCompSynonyms.Name = "chkCompSynonyms";
+            this.chkCompSynonyms.Size = new System.Drawing.Size(74, 17);
+            this.chkCompSynonyms.TabIndex = 28;
+            this.chkCompSynonyms.Text = "Synonyms";
+            this.chkCompSynonyms.UseVisualStyleBackColor = true;
+            // 
             // gradientPanel4
             // 
             this.gradientPanel4.Controls.Add(this.chkCompCLRStore);
             this.gradientPanel4.Controls.Add(this.chkCompAssemblys);
-            this.gradientPanel4.Controls.Add(this.checkBox4);
+            this.gradientPanel4.Controls.Add(this.chkCompCLRAggregates);
             this.gradientPanel4.Controls.Add(this.chkCompCLRTrigger);
             this.gradientPanel4.Controls.Add(this.chkCompCLRUDT);
             this.gradientPanel4.Controls.Add(this.chkCompCLRFunctions);
-            this.gradientPanel4.Location = new System.Drawing.Point(182, 176);
+            this.gradientPanel4.Location = new System.Drawing.Point(182, 200);
             this.gradientPanel4.Name = "gradientPanel4";
-            this.gradientPanel4.Size = new System.Drawing.Size(171, 195);
+            this.gradientPanel4.Size = new System.Drawing.Size(171, 171);
             this.gradientPanel4.TabIndex = 5;
             // 
             // gradientPanel3
             // 
-            this.gradientPanel3.Controls.Add(this.checkBox1);
+            this.gradientPanel3.Controls.Add(this.chkCompSecurity);
+            this.gradientPanel3.Controls.Add(this.chkCompPermissions);
             this.gradientPanel3.Controls.Add(this.chkFullTextPath);
             this.gradientPanel3.Controls.Add(this.chkCompUsers);
             this.gradientPanel3.Controls.Add(this.chkCompSchemas);
@@ -921,21 +938,21 @@ namespace OpenDBDiff.SqlServer.Ui
             this.gradientPanel3.Controls.Add(this.chkFullText);
             this.gradientPanel3.Location = new System.Drawing.Point(182, 33);
             this.gradientPanel3.Name = "gradientPanel3";
-            this.gradientPanel3.Size = new System.Drawing.Size(171, 137);
+            this.gradientPanel3.Size = new System.Drawing.Size(171, 161);
             this.gradientPanel3.TabIndex = 4;
             // 
-            // checkBox1
+            // chkCompPermissions
             // 
-            this.checkBox1.AutoSize = true;
-            this.checkBox1.Checked = true;
-            this.checkBox1.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBox1.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.checkBox1.Location = new System.Drawing.Point(10, 120);
-            this.checkBox1.Name = "checkBox1";
-            this.checkBox1.Size = new System.Drawing.Size(81, 17);
-            this.checkBox1.TabIndex = 37;
-            this.checkBox1.Text = "Permissions";
-            this.checkBox1.UseVisualStyleBackColor = true;
+            this.chkCompPermissions.AutoSize = true;
+            this.chkCompPermissions.Checked = true;
+            this.chkCompPermissions.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkCompPermissions.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.chkCompPermissions.Location = new System.Drawing.Point(28, 139);
+            this.chkCompPermissions.Name = "chkCompPermissions";
+            this.chkCompPermissions.Size = new System.Drawing.Size(81, 17);
+            this.chkCompPermissions.TabIndex = 37;
+            this.chkCompPermissions.Text = "Permissions";
+            this.chkCompPermissions.UseVisualStyleBackColor = true;
             // 
             // gradientPanel2
             // 
@@ -1066,6 +1083,7 @@ namespace OpenDBDiff.SqlServer.Ui
             this.columnHeader3,
             this.columnHeader4});
             this.lstFilters.FullRowSelect = true;
+            this.lstFilters.HideSelection = false;
             this.lstFilters.Location = new System.Drawing.Point(7, 8);
             this.lstFilters.Name = "lstFilters";
             this.lstFilters.Size = new System.Drawing.Size(509, 333);
@@ -1073,7 +1091,7 @@ namespace OpenDBDiff.SqlServer.Ui
             this.lstFilters.UseCompatibleStateImageBehavior = false;
             this.lstFilters.View = System.Windows.Forms.View.Details;
             this.lstFilters.DoubleClick += new System.EventHandler(this.lstFilters_DoubleClick);
-            //
+            // 
             // columnHeader1
             // 
             this.columnHeader1.Text = "Exclusion pattern";
@@ -1399,18 +1417,35 @@ namespace OpenDBDiff.SqlServer.Ui
             this.chkReloadDB.Text = "Reload database comparison after each update";
             this.chkReloadDB.UseVisualStyleBackColor = false;
             // 
-            // IncludeSynonymsCheckBox
+            // chkCompSecurity
             // 
-            this.IncludeSynonymsCheckBox.AutoSize = true;
-            this.IncludeSynonymsCheckBox.Checked = true;
-            this.IncludeSynonymsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.IncludeSynonymsCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.IncludeSynonymsCheckBox.Location = new System.Drawing.Point(13, 144);
-            this.IncludeSynonymsCheckBox.Name = "IncludeSynonymsCheckBox";
-            this.IncludeSynonymsCheckBox.Size = new System.Drawing.Size(74, 17);
-            this.IncludeSynonymsCheckBox.TabIndex = 28;
-            this.IncludeSynonymsCheckBox.Text = "Synonyms";
-            this.IncludeSynonymsCheckBox.UseVisualStyleBackColor = true;
+            this.chkCompSecurity.AutoSize = true;
+            this.chkCompSecurity.Checked = true;
+            this.chkCompSecurity.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkCompSecurity.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chkCompSecurity.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.chkCompSecurity.Location = new System.Drawing.Point(10, 7);
+            this.chkCompSecurity.Name = "chkCompSecurity";
+            this.chkCompSecurity.Size = new System.Drawing.Size(72, 17);
+            this.chkCompSecurity.TabIndex = 38;
+            this.chkCompSecurity.Text = "Security";
+            this.chkCompSecurity.UseVisualStyleBackColor = true;
+            this.chkCompSecurity.CheckedChanged += new System.EventHandler(this.chkCompSecurity_CheckedChanged);
+            // 
+            // chkCompProgrammability
+            // 
+            this.chkCompProgrammability.AutoSize = true;
+            this.chkCompProgrammability.Checked = true;
+            this.chkCompProgrammability.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkCompProgrammability.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chkCompProgrammability.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.chkCompProgrammability.Location = new System.Drawing.Point(14, 7);
+            this.chkCompProgrammability.Name = "chkCompProgrammability";
+            this.chkCompProgrammability.Size = new System.Drawing.Size(114, 17);
+            this.chkCompProgrammability.TabIndex = 39;
+            this.chkCompProgrammability.Text = "Programmability";
+            this.chkCompProgrammability.UseVisualStyleBackColor = true;
+            this.chkCompProgrammability.CheckedChanged += new System.EventHandler(this.chkCompProgrammability_CheckedChanged);
             // 
             // SqlOptionsFront
             // 
@@ -1472,11 +1507,11 @@ namespace OpenDBDiff.SqlServer.Ui
         private CheckBox chkIndex;
         private CheckBox chkTableOption;
         private CheckBox chkCompXMLSchemas;
-        private CheckBox chkCompFunciones;
+        private CheckBox chkCompFunctions;
         private CheckBox chkCompStoredProcedure;
         private CheckBox chkTables;
         private CheckBox chkCompTriggers;
-        private CheckBox chkCompVistas;
+        private CheckBox chkCompViews;
         private Label label2;
         private TextBox txtDefaultReal;
         private Label label3;
@@ -1521,9 +1556,9 @@ namespace OpenDBDiff.SqlServer.Ui
         private CheckBox chkCompCLRTrigger;
         private CheckBox chkCompCLRFunctions;
         private CheckBox chkCompCLRUDT;
-        private CheckBox checkBox4;
-        private CheckBox checkPartitionFunction;
-        private CheckBox checkBox5;
+        private CheckBox chkCompCLRAggregates;
+        private CheckBox chkPartitionFunction;
+        private CheckBox chkPartitionSchemas;
         private TabPage tabPage5;
         private RadioButton rdoCaseAutomatic;
         private RadioButton rdoCaseSensitive;
@@ -1556,7 +1591,7 @@ namespace OpenDBDiff.SqlServer.Ui
         private Panel gradientPanel10;
         private CheckBox chkTableLockEscalation;
         private CheckBox chkTableChangeTracking;
-        private CheckBox checkBox1;
+        private CheckBox chkCompPermissions;
         private Panel gradientPanel12;
         private Label label13;
         private Panel gradientPanel11;
@@ -1571,6 +1606,8 @@ namespace OpenDBDiff.SqlServer.Ui
         private RadioButton optScriptSchemaDrop;
         private CheckBox chkReloadDB;
         private Button DeleteNameFilterButton;
-        private CheckBox IncludeSynonymsCheckBox;
+        private CheckBox chkCompSynonyms;
+        private CheckBox chkCompProgrammability;
+        private CheckBox chkCompSecurity;
     }
 }

--- a/OpenDBDiff.SqlServer.Ui/Front/SqlOptionsFront.cs
+++ b/OpenDBDiff.SqlServer.Ui/Front/SqlOptionsFront.cs
@@ -1,5 +1,6 @@
 using OpenDBDiff.Abstractions.Schema;
 using OpenDBDiff.Abstractions.Schema.Model;
+using OpenDBDiff.SqlServer.Schema.Model;
 using OpenDBDiff.SqlServer.Schema.Options;
 using System;
 using System.Windows.Forms;
@@ -50,6 +51,7 @@ namespace OpenDBDiff.SqlServer.Ui
             chkCompCLRStore.Checked = SQLOption.Ignore.FilterCLRStoredProcedure;
             chkCompCLRTrigger.Checked = SQLOption.Ignore.FilterCLRTrigger;
             chkCompCLRUDT.Checked = SQLOption.Ignore.FilterCLRUDT;
+            chkCompCLRAggregates.Checked = SQLOption.Ignore.FilterCLRAggregates;
 
             chkConstraints.Checked = SQLOption.Ignore.FilterConstraint;
             chkConstraintsPK.Checked = SQLOption.Ignore.FilterConstraintPK;
@@ -57,38 +59,44 @@ namespace OpenDBDiff.SqlServer.Ui
             chkConstraintsUK.Checked = SQLOption.Ignore.FilterConstraintUK;
             chkConstraintsCheck.Checked = SQLOption.Ignore.FilterConstraintCheck;
 
-            chkCompExtendedProperties.Checked = SQLOption.Ignore.FilterExtendedProperties;
-            chkCompFunciones.Checked = SQLOption.Ignore.FilterFunction;
             chkIndex.Checked = SQLOption.Ignore.FilterIndex;
             chkIndexFillFactor.Checked = SQLOption.Ignore.FilterIndexFillFactor;
             chkIndexIncludeColumns.Checked = SQLOption.Ignore.FilterIndexIncludeColumns;
             chkIndexFilter.Checked = SQLOption.Ignore.FilterIndexFilter;
-            chkFullText.Checked = SQLOption.Ignore.FilterFullText;
-            chkFullTextPath.Checked = SQLOption.Ignore.FilterFullTextPath;
+            chkIndexRowLock.Checked = SQLOption.Ignore.FilterIndexRowLock;
 
-            chkCompSchemas.Checked = SQLOption.Ignore.FilterSchema;
+            chkCompProgrammability.Checked = SQLOption.Ignore.FilterProgrammability;
+            chkPartitionFunction.Checked = SQLOption.Ignore.FilterPartitionFunction;
+            chkPartitionSchemas.Checked = SQLOption.Ignore.FilterPartitionScheme;
+            chkCompTriggersDDL.Checked = SQLOption.Ignore.FilterDDLTriggers;
+            chkCompFunctions.Checked = SQLOption.Ignore.FilterFunction;
+            chkCompRules.Checked = SQLOption.Ignore.FilterRules;
             chkCompStoredProcedure.Checked = SQLOption.Ignore.FilterStoredProcedure;
-            chkTableOption.Checked = SQLOption.Ignore.FilterTableOption;
+            chkCompTriggers.Checked = SQLOption.Ignore.FilterTrigger;
+            chkCompUDT.Checked = SQLOption.Ignore.FilterUserDataType;
+            chkCompViews.Checked = SQLOption.Ignore.FilterView;
+            chkCompXMLSchemas.Checked = SQLOption.Ignore.FilterXMLSchema;
+            chkCompSynonyms.Checked = SQLOption.Ignore.FilterSynonyms;
+
             chkTables.Checked = SQLOption.Ignore.FilterTable;
             chkTablesColumnIdentity.Checked = SQLOption.Ignore.FilterColumnIdentity;
             chkTablesColumnCollation.Checked = SQLOption.Ignore.FilterColumnCollation;
             chkTableLockEscalation.Checked = SQLOption.Ignore.FilterTableLockEscalation;
+            chkTableOption.Checked = SQLOption.Ignore.FilterTableOption;
             chkTableChangeTracking.Checked = SQLOption.Ignore.FilterTableChangeTracking;
-
             chkTablesColumnOrder.Checked = SQLOption.Ignore.FilterColumnOrder;
-            chkIgnoreNotForReplication.Checked = SQLOption.Ignore.FilterNotForReplication;
 
-            chkCompTriggersDDL.Checked = SQLOption.Ignore.FilterDDLTriggers;
-            chkCompTriggers.Checked = SQLOption.Ignore.FilterTrigger;
-            chkCompUDT.Checked = SQLOption.Ignore.FilterUserDataType;
-            chkCompVistas.Checked = SQLOption.Ignore.FilterView;
-            chkCompXMLSchemas.Checked = SQLOption.Ignore.FilterXMLSchema;
+            chkIgnoreNotForReplication.Checked = SQLOption.Ignore.FilterNotForReplication;
+            chkCompExtendedProperties.Checked = SQLOption.Ignore.FilterExtendedProperties;
+
+            chkCompSecurity.Checked = SQLOption.Ignore.FilterSecurity;
             chkFileGroups.Checked = SQLOption.Ignore.FilterTableFileGroup;
+            chkFullText.Checked = SQLOption.Ignore.FilterFullText;
+            chkFullTextPath.Checked = SQLOption.Ignore.FilterFullTextPath;
             chkCompUsers.Checked = SQLOption.Ignore.FilterUsers;
             chkCompRoles.Checked = SQLOption.Ignore.FilterRoles;
-            chkCompRules.Checked = SQLOption.Ignore.FilterRules;
-
-            IncludeSynonymsCheckBox.Checked = SQLOption.Ignore.FilterSynonyms;
+            chkCompSchemas.Checked = SQLOption.Ignore.FilterSchema;
+            chkCompPermissions.Checked = SQLOption.Ignore.FilterPermissions;
 
             if (SQLOption.Script.AlterObjectOnSchemaBinding)
                 optScriptSchemaBindingAlter.Checked = true;
@@ -131,6 +139,7 @@ namespace OpenDBDiff.SqlServer.Ui
             SQLOption.Ignore.FilterCLRStoredProcedure = chkCompCLRStore.Checked && chkCompAssemblys.Checked;
             SQLOption.Ignore.FilterCLRTrigger = chkCompCLRTrigger.Checked && chkCompAssemblys.Checked;
             SQLOption.Ignore.FilterCLRUDT = chkCompCLRUDT.Checked && chkCompAssemblys.Checked;
+            SQLOption.Ignore.FilterCLRAggregates = chkCompCLRAggregates.Checked && chkCompAssemblys.Checked;
 
             SQLOption.Ignore.FilterConstraint = chkConstraints.Checked;
             SQLOption.Ignore.FilterConstraintPK = chkConstraintsPK.Checked;
@@ -138,15 +147,11 @@ namespace OpenDBDiff.SqlServer.Ui
             SQLOption.Ignore.FilterConstraintUK = chkConstraintsUK.Checked;
             SQLOption.Ignore.FilterConstraintCheck = chkConstraintsCheck.Checked;
 
-            SQLOption.Ignore.FilterFunction = chkCompFunciones.Checked;
-
             SQLOption.Ignore.FilterIndex = chkIndex.Checked;
             SQLOption.Ignore.FilterIndexFillFactor = chkIndexFillFactor.Checked && chkIndex.Checked;
             SQLOption.Ignore.FilterIndexIncludeColumns = chkIndexIncludeColumns.Checked && chkIndex.Checked;
             SQLOption.Ignore.FilterIndexFilter = chkIndexFilter.Checked && chkIndex.Checked;
-
-            SQLOption.Ignore.FilterSchema = chkCompSchemas.Checked;
-            SQLOption.Ignore.FilterStoredProcedure = chkCompStoredProcedure.Checked;
+            SQLOption.Ignore.FilterIndexRowLock = chkIndexRowLock.Checked && chkIndex.Checked;
 
             SQLOption.Ignore.FilterTable = chkTables.Checked;
             SQLOption.Ignore.FilterColumnIdentity = chkTablesColumnIdentity.Checked && chkTables.Checked;
@@ -156,19 +161,28 @@ namespace OpenDBDiff.SqlServer.Ui
             SQLOption.Ignore.FilterTableLockEscalation = chkTableLockEscalation.Checked && chkTables.Checked;
             SQLOption.Ignore.FilterTableChangeTracking = chkTableChangeTracking.Checked && chkTables.Checked;
 
-            SQLOption.Ignore.FilterTableFileGroup = chkFileGroups.Checked;
+            SQLOption.Ignore.FilterProgrammability = chkCompProgrammability.Checked;
             SQLOption.Ignore.FilterTrigger = chkCompTriggers.Checked;
             SQLOption.Ignore.FilterDDLTriggers = chkCompTriggersDDL.Checked;
             SQLOption.Ignore.FilterUserDataType = chkCompUDT.Checked;
-            SQLOption.Ignore.FilterView = chkCompVistas.Checked;
+            SQLOption.Ignore.FilterView = chkCompViews.Checked;
             SQLOption.Ignore.FilterXMLSchema = chkCompXMLSchemas.Checked;
             SQLOption.Ignore.FilterExtendedProperties = chkCompExtendedProperties.Checked;
+            SQLOption.Ignore.FilterSynonyms = chkCompSynonyms.Checked;
+            SQLOption.Ignore.FilterStoredProcedure = chkCompStoredProcedure.Checked;
+            SQLOption.Ignore.FilterFunction = chkCompFunctions.Checked;
+            SQLOption.Ignore.FilterPartitionScheme = chkPartitionSchemas.Checked;
+            SQLOption.Ignore.FilterPartitionFunction = chkPartitionFunction.Checked;
+
+            SQLOption.Ignore.FilterSecurity = chkCompSecurity.Checked;
+            SQLOption.Ignore.FilterTableFileGroup = chkFileGroups.Checked;
             SQLOption.Ignore.FilterUsers = chkCompUsers.Checked;
             SQLOption.Ignore.FilterRoles = chkCompRoles.Checked;
             SQLOption.Ignore.FilterRules = chkCompRules.Checked;
             SQLOption.Ignore.FilterFullText = chkFullText.Checked;
             SQLOption.Ignore.FilterFullTextPath = chkFullTextPath.Checked;
-            SQLOption.Ignore.FilterSynonyms = IncludeSynonymsCheckBox.Checked;
+            SQLOption.Ignore.FilterPermissions = chkCompPermissions.Checked;
+            SQLOption.Ignore.FilterSchema = chkCompSchemas.Checked;
 
             SQLOption.Ignore.FilterNotForReplication = chkIgnoreNotForReplication.Checked;
             SQLOption.Script.AlterObjectOnSchemaBinding = optScriptSchemaBindingAlter.Checked;
@@ -247,6 +261,7 @@ namespace OpenDBDiff.SqlServer.Ui
             chkCompCLRTrigger.Enabled = chkCompAssemblys.Checked;
             chkCompCLRFunctions.Enabled = chkCompAssemblys.Checked;
             chkCompCLRUDT.Enabled = chkCompAssemblys.Checked;
+            chkCompCLRAggregates.Enabled = chkCompAssemblys.Checked;
         }
 
         private void DeleteNameFilterButton_Click(object sender, EventArgs e)
@@ -274,6 +289,32 @@ namespace OpenDBDiff.SqlServer.Ui
                 AddExclusionPatternForm itemForm = new AddExclusionPatternForm(SQLOption, lstFilters.SelectedItems[0].Index);
                 itemForm.ShowDialog(this);
             }
+        }
+
+        private void chkCompProgrammability_CheckedChanged(object sender, EventArgs e)
+        {
+            chkCompTriggersDDL.Checked = chkCompProgrammability.Checked;
+            chkCompFunctions.Checked = chkCompProgrammability.Checked;
+            chkPartitionFunction.Checked = chkCompProgrammability.Checked;
+            chkPartitionSchemas.Checked = chkCompProgrammability.Checked;
+            chkCompRules.Checked = chkCompProgrammability.Checked;
+            chkCompStoredProcedure.Checked = chkCompProgrammability.Checked;
+            chkCompSynonyms.Checked = chkCompProgrammability.Checked;
+            chkCompTriggers.Checked = chkCompProgrammability.Checked;
+            chkCompUDT.Checked = chkCompProgrammability.Checked;
+            chkCompViews.Checked = chkCompProgrammability.Checked;
+            chkCompXMLSchemas.Checked = chkCompProgrammability.Checked;
+        }
+
+        private void chkCompSecurity_CheckedChanged(object sender, EventArgs e)
+        {
+            chkFileGroups.Checked = chkCompSecurity.Checked;
+            chkFullText.Checked = chkCompSecurity.Checked;
+            chkFullTextPath.Checked = chkCompSecurity.Checked;
+            chkCompUsers.Checked = chkCompSecurity.Checked;
+            chkCompRoles.Checked = chkCompSecurity.Checked;
+            chkCompSchemas.Checked = chkCompSecurity.Checked;
+            chkCompPermissions.Checked = chkCompSecurity.Checked;
         }
     }
 }

--- a/OpenDBDiff/OpenDBDiff.csproj
+++ b/OpenDBDiff/OpenDBDiff.csproj
@@ -89,6 +89,12 @@
     <Compile Include="Extensions\ExceptionExtensions.cs" />
     <Compile Include="Extensions\IEnumerableExtensions.cs" />
     <Compile Include="Extensions\ScintillaExtensions.cs" />
+    <Compile Include="UI\CompareProgressControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="UI\CompareProgressControl.Designer.cs">
+      <DependentUpon>CompareProgressControl.cs</DependentUpon>
+    </Compile>
     <Compile Include="UI\DataCompareForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -140,6 +146,9 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <EmbeddedResource Include="UI\CompareProgressControl.resx">
+      <DependentUpon>CompareProgressControl.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="UI\DatabaseProgressControl.resx">
       <DependentUpon>DatabaseProgressControl.cs</DependentUpon>
     </EmbeddedResource>
@@ -190,6 +199,10 @@
     <ProjectReference Include="..\OpenDBDiff.Abstractions.Ui\OpenDBDiff.Abstractions.Ui.csproj">
       <Project>{e82cfc94-de8c-4edd-aa0c-f78abae03768}</Project>
       <Name>OpenDBDiff.Abstractions.Ui</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\OpenDBDiff.SqlServer.Schema\OpenDBDiff.SqlServer.Schema.csproj">
+      <Project>{32AC9AF6-DB93-4354-B69F-6DBC65C70867}</Project>
+      <Name>OpenDBDiff.SqlServer.Schema</Name>
     </ProjectReference>
     <ProjectReference Include="..\OpenDBDiff.SqlServer.Ui\OpenDBDiff.SqlServer.Ui.csproj">
       <Project>{ef2f571e-a7ad-40be-8500-50a039159fc1}</Project>

--- a/OpenDBDiff/UI/CompareProgressControl.Designer.cs
+++ b/OpenDBDiff/UI/CompareProgressControl.Designer.cs
@@ -1,0 +1,105 @@
+﻿using System.ComponentModel;
+using System.Windows.Forms;
+
+namespace OpenDBDiff.UI
+{
+    partial class CompareProgressControl
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.lblCompare = new System.Windows.Forms.Label();
+            this.lblMessage = new System.Windows.Forms.Label();
+            this.progressBar1 = new System.Windows.Forms.ProgressBar();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.BackColor = System.Drawing.Color.Transparent;
+            this.pictureBox1.Image = global::OpenDBDiff.Properties.Resources.compare;
+            this.pictureBox1.Location = new System.Drawing.Point(3, 3);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(15, 18);
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox1.TabIndex = 33;
+            this.pictureBox1.TabStop = false;
+            // 
+            // lblDatabase
+            // 
+            this.lblCompare.AutoSize = true;
+            this.lblCompare.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblCompare.Location = new System.Drawing.Point(22, 6);
+            this.lblCompare.Name = "lblDatabase";
+            this.lblCompare.Size = new System.Drawing.Size(60, 13);
+            this.lblCompare.TabIndex = 34;
+            this.lblCompare.Text = "Compare:";
+            // 
+            // lblMessage
+            // 
+            this.lblMessage.AutoSize = true;
+            this.lblMessage.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(192)))));
+            this.lblMessage.Location = new System.Drawing.Point(22, 23);
+            this.lblMessage.Name = "lblMessage";
+            this.lblMessage.Size = new System.Drawing.Size(0, 13);
+            this.lblMessage.TabIndex = 35;
+            // 
+            // progressBar1
+            // 
+            this.progressBar1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.progressBar1.Location = new System.Drawing.Point(25, 40);
+            this.progressBar1.Name = "progressBar1";
+            this.progressBar1.Size = new System.Drawing.Size(301, 16);
+            this.progressBar1.TabIndex = 36;
+            this.progressBar1.Value = 50;
+            // 
+            // CompareProgressControl
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.WhiteSmoke;
+            this.Controls.Add(this.progressBar1);
+            this.Controls.Add(this.lblMessage);
+            this.Controls.Add(this.lblCompare);
+            this.Controls.Add(this.pictureBox1);
+            this.Name = "CompareProgressControl";
+            this.Size = new System.Drawing.Size(329, 59);
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private PictureBox pictureBox1;
+        private Label lblCompare;
+        private Label lblMessage;
+        private ProgressBar progressBar1;
+    }
+}

--- a/OpenDBDiff/UI/CompareProgressControl.cs
+++ b/OpenDBDiff/UI/CompareProgressControl.cs
@@ -1,0 +1,47 @@
+﻿using System.Windows.Forms;
+
+namespace OpenDBDiff.UI
+{
+    public partial class CompareProgressControl : UserControl
+    {
+        public CompareProgressControl()
+        {
+            InitializeComponent();
+        }
+
+        public string DatabaseName
+        {
+            get { return lblCompare.Text; }
+            set { lblCompare.Text = value; }
+        }
+
+        public string Message
+        {
+            get
+            {
+                return lblMessage.Text;
+            }
+            set
+            {
+                lblMessage.Text = value;
+                lblMessage.Refresh();
+            }
+        }
+
+        public int Maximum
+        {
+            get { return progressBar1.Maximum; }
+            set { progressBar1.Maximum = value; }
+        }
+
+        public int Value
+        {
+            get { return progressBar1.Value; }
+            set
+            {
+                progressBar1.Value = value;
+                progressBar1.Refresh();
+            }
+        }
+    }
+}

--- a/OpenDBDiff/UI/CompareProgressControl.resx
+++ b/OpenDBDiff/UI/CompareProgressControl.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/OpenDBDiff/UI/MainForm.cs
+++ b/OpenDBDiff/UI/MainForm.cs
@@ -65,6 +65,11 @@ namespace OpenDBDiff.UI
                         throw new SchemaException(progress.Error.Message, progress.Error);
                     }
 
+                    if (progress.Destination == null || progress.Origin == null)
+                    {
+                        return;
+                    }
+
                     txtSyncScript.LexerLanguage = this.ProjectSelectorHandler.GetScriptLanguage();
                     txtSyncScript.ReadOnly = false;
                     errorLocation = "Generating Synchronized Script";

--- a/OpenDBDiff/UI/ProgressForm.Designer.cs
+++ b/OpenDBDiff/UI/ProgressForm.Designer.cs
@@ -35,24 +35,25 @@ namespace OpenDBDiff.UI
             this.gradientPanel1 = new System.Windows.Forms.Panel();
             this.lblName = new System.Windows.Forms.Label();
             this.panel1 = new System.Windows.Forms.Panel();
-            this.originProgressControl = new OpenDBDiff.UI.DatabaseProgressControl();
+            this.compareProgressControl = new OpenDBDiff.UI.CompareProgressControl();
             this.destinationProgressControl = new OpenDBDiff.UI.DatabaseProgressControl();
+            this.originProgressControl = new OpenDBDiff.UI.DatabaseProgressControl();
             this.gradientPanel1.SuspendLayout();
             this.panel1.SuspendLayout();
             this.SuspendLayout();
-            //
+            // 
             // gradientPanel1
-            //
-            this.gradientPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            // 
+            this.gradientPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.gradientPanel1.Controls.Add(this.lblName);
             this.gradientPanel1.Location = new System.Drawing.Point(0, 0);
             this.gradientPanel1.Name = "gradientPanel1";
             this.gradientPanel1.Size = new System.Drawing.Size(499, 58);
             this.gradientPanel1.TabIndex = 27;
-            //
+            // 
             // lblName
-            //
+            // 
             this.lblName.AutoSize = true;
             this.lblName.Font = new System.Drawing.Font("Arial", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblName.Location = new System.Drawing.Point(12, 16);
@@ -60,33 +61,34 @@ namespace OpenDBDiff.UI
             this.lblName.Size = new System.Drawing.Size(200, 24);
             this.lblName.TabIndex = 24;
             this.lblName.Text = "Compare Progress";
-            //
+            // 
             // panel1
-            //
-            this.panel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            // 
+            this.panel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.panel1.BackColor = System.Drawing.Color.White;
+            this.panel1.Controls.Add(this.compareProgressControl);
             this.panel1.Controls.Add(this.destinationProgressControl);
             this.panel1.Controls.Add(this.originProgressControl);
             this.panel1.Location = new System.Drawing.Point(0, 57);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(499, 173);
+            this.panel1.Size = new System.Drawing.Size(499, 248);
             this.panel1.TabIndex = 30;
-            //
-            // originProgressControl
-            //
-            this.originProgressControl.BackColor = System.Drawing.Color.WhiteSmoke;
-            this.originProgressControl.DatabaseName = "Source:";
-            this.originProgressControl.Location = new System.Drawing.Point(12, 92);
-            this.originProgressControl.Maximum = 100;
-            this.originProgressControl.Message = "";
-            this.originProgressControl.Name = "sourceProgressControl";
-            this.originProgressControl.Size = new System.Drawing.Size(472, 64);
-            this.originProgressControl.TabIndex = 35;
-            this.originProgressControl.Value = 0;
-            //
+            // 
+            // compareProgressControl1
+            // 
+            this.compareProgressControl.BackColor = System.Drawing.Color.WhiteSmoke;
+            this.compareProgressControl.DatabaseName = "Compare:";
+            this.compareProgressControl.Location = new System.Drawing.Point(12, 171);
+            this.compareProgressControl.Maximum = 100;
+            this.compareProgressControl.Message = "";
+            this.compareProgressControl.Name = "compareProgressControl1";
+            this.compareProgressControl.Size = new System.Drawing.Size(472, 64);
+            this.compareProgressControl.TabIndex = 36;
+            this.compareProgressControl.Value = 0;
+            // 
             // destinationProgressControl
-            //
+            // 
             this.destinationProgressControl.BackColor = System.Drawing.Color.WhiteSmoke;
             this.destinationProgressControl.DatabaseName = "Destination:";
             this.destinationProgressControl.Location = new System.Drawing.Point(12, 15);
@@ -96,13 +98,25 @@ namespace OpenDBDiff.UI
             this.destinationProgressControl.Size = new System.Drawing.Size(472, 64);
             this.destinationProgressControl.TabIndex = 34;
             this.destinationProgressControl.Value = 0;
-            //
+            // 
+            // originProgressControl
+            // 
+            this.originProgressControl.BackColor = System.Drawing.Color.WhiteSmoke;
+            this.originProgressControl.DatabaseName = "Source:";
+            this.originProgressControl.Location = new System.Drawing.Point(12, 92);
+            this.originProgressControl.Maximum = 100;
+            this.originProgressControl.Message = "";
+            this.originProgressControl.Name = "originProgressControl";
+            this.originProgressControl.Size = new System.Drawing.Size(472, 64);
+            this.originProgressControl.TabIndex = 35;
+            this.originProgressControl.Value = 0;
+            // 
             // ProgressForm
-            //
+            // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Control;
-            this.ClientSize = new System.Drawing.Size(496, 230);
+            this.ClientSize = new System.Drawing.Size(496, 304);
             this.Controls.Add(this.panel1);
             this.Controls.Add(this.gradientPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
@@ -128,5 +142,6 @@ namespace OpenDBDiff.UI
         private Panel panel1;
         private DatabaseProgressControl destinationProgressControl;
         private DatabaseProgressControl originProgressControl;
+        private CompareProgressControl compareProgressControl;
     }
 }

--- a/OpenDBDiff/UI/ProgressForm.cs
+++ b/OpenDBDiff/UI/ProgressForm.cs
@@ -17,7 +17,7 @@ namespace OpenDBDiff.UI
         private IGenerator OriginGenerator;
         private IGenerator DestinationGenerator;
         private bool IsProcessing = false;
-        //private IDatabase originClone = null;
+        private IDatabase originClone = null;
         private readonly IDatabaseComparer Comparer;
 
         // TODO: thread-safe error reporting
@@ -93,7 +93,7 @@ namespace OpenDBDiff.UI
                         originProgressControl.Value = OriginGenerator.GetMaxValue();
                     }));
 
-                    //originClone = await Task.Run(() => (IDatabase)Origin.Clone(null));
+                    originClone = await Task.Run(() => (IDatabase)Origin.Clone(null));
 
                     this.ErrorLocation = "Comparing Databases";
 
@@ -101,7 +101,7 @@ namespace OpenDBDiff.UI
 
                     Destination = await Task.Run(() => Comparer.Compare(Origin, Destination));
 
-                    //Origin = originClone;
+                    Origin = originClone;
 
                 }
                 catch (Exception err)


### PR DESCRIPTION
1. Fixed Thread Deadlocks when updating ProgressForm.
![image](https://github.com/OpenDBDiff/OpenDBDiff/assets/63010692/1adba779-c8cc-4816-b1fd-d634be8c07ca)

2. Added check on MainForm to prevent NullReference Exception when closing ProgressForm while ProgressForm_Activated is executing.
![image](https://github.com/OpenDBDiff/OpenDBDiff/assets/63010692/9bfb6b50-69f8-4b35-9219-f548cddb7081)

3. IsProcessing will now be set to true when ProgressForm_Activated fires. This will prevent ProgressForm_Activated from refiring when ProgressForm loses and regains focus.
![image](https://github.com/OpenDBDiff/OpenDBDiff/assets/63010692/b2046b7f-37cd-401a-b541-434265bf8673)
